### PR TITLE
Update documentation to match v1.4.0 implementation

### DIFF
--- a/docs/api/compose-webview.md
+++ b/docs/api/compose-webview.md
@@ -29,14 +29,8 @@ fun ComposeWebView(
     jsConfirmContent: @Composable (JsDialogState.Confirm) -> Unit = {},
     jsPromptContent: @Composable (JsDialogState.Prompt) -> Unit = {},
     customViewContent: (@Composable (CustomViewState) -> Unit)? = null,
-    onPageStarted: (WebView, String?, PlatformBitmap?) -> Unit = { _, _, _ -> },
-    onPageFinished: (WebView, String?) -> Unit = { _, _ -> },
-    onReceivedError: (WebView, PlatformWebResourceRequest?, PlatformWebResourceError?) -> Unit = { _, _, _ -> },
-    onProgressChanged: (WebView, Int) -> Unit = { _, _ -> },
     onDownloadStart: ((String, String, String, String, Long) -> Unit)? = null,
     onFindResultReceived: ((Int, Int, Boolean) -> Unit)? = null,
-    onPermissionRequest: (PlatformPermissionRequest) -> Unit = {},
-    onConsoleMessage: ((WebView, ConsoleMessage) -> Boolean)? = null
 )
 ```
 
@@ -78,14 +72,8 @@ fun ComposeWebView(
 | `jsConfirmContent` | `@Composable (JsDialogState.Confirm) -> Unit` | Custom UI for JavaScript `confirm()` dialogs. | Android, iOS |
 | `jsPromptContent` | `@Composable (JsDialogState.Prompt) -> Unit` | Custom UI for JavaScript `prompt()` dialogs. | Android, iOS |
 | `customViewContent` | `(@Composable (CustomViewState) -> Unit)?` | Custom view content (e.g., fullscreen video). | Android |
-| `onPageStarted` | `(WebView, String?, PlatformBitmap?) -> Unit` | Standard `WebViewClient` callback for page load start. | Android, iOS, Desktop (partial) |
-| `onPageFinished` | `(WebView, String?) -> Unit` | Standard `WebViewClient` callback for page load completion. | Android, iOS, Desktop (partial) |
-| `onReceivedError` | `(WebView, PlatformWebResourceRequest?, PlatformWebResourceError?) -> Unit` | Callback for page load errors. | Android, iOS, Desktop (partial) |
-| `onProgressChanged` | `(WebView, Int) -> Unit` | Callback for loading progress updates (0-100). | Android (real-time), iOS (100ms polling) |
 | `onDownloadStart` | `((String, String, String, String, Long) -> Unit)?` | Callback for download requests (url, userAgent, contentDisposition, mimeType, contentLength). | Android, iOS (partial) |
 | `onFindResultReceived` | `((Int, Int, Boolean) -> Unit)?` | Callback for text search results (activeMatchOrdinal, numberOfMatches, isDoneCounting). | Android |
-| `onPermissionRequest` | `(PlatformPermissionRequest) -> Unit` | Callback for permission requests (e.g., camera, microphone). | Android, iOS (partial) |
-| `onConsoleMessage` | `((WebView, ConsoleMessage) -> Boolean)?` | Callback for JavaScript console messages. Return true to suppress default logging. | Android, iOS |
 
 \* **Controller**: All platforms support basic navigation, but some features (like zoom) are platform-specific. See `WebViewController` documentation for details.
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -17,7 +17,7 @@ Holds the reactive state of the WebView.
 | `isLoading` | `Boolean` | Whether the WebView is currently loading a page. | All platforms |
 | `loadingState` | `LoadingState` | Detailed loading progress state (Initializing, Loading, Finished, Failed, Cancelled). | All platforms* |
 | `pageTitle` | `String?` | The current page title. | All platforms |
-| `pageIcon` | `Bitmap?` | The current page favicon. | Android, iOS, Desktop |
+| `pageIcon` | `PlatformBitmap?` | The current page favicon. | Android, iOS, Desktop |
 | `scrollPosition` | `ScrollPosition` | Current scroll position (x, y) in pixels. | Android (real-time), iOS (100ms polling), Web (CORS-limited) |
 | `errorsForCurrentRequest` | `List<WebViewError>` | Errors that occurred during the current page load. | Android, iOS, Desktop (partial), Web (limited) |
 | `jsDialogState` | `JsDialogState?` | Active JavaScript dialog (Alert, Confirm, Prompt). | Android, iOS |
@@ -60,8 +60,8 @@ Controls the navigation and execution of the WebView.
 
 | Method | Platform Support | Notes |
 | :--- | :--- | :--- |
-| `zoomIn()` | Android, Desktop | iOS: Not supported (pinch-to-zoom only) |
-| `zoomOut()` | Android, Desktop | iOS: Not supported (pinch-to-zoom only) |
+| `zoomIn(): Boolean` | Android, Desktop | iOS: Not supported (pinch-to-zoom only) |
+| `zoomOut(): Boolean` | Android, Desktop | iOS: Not supported (pinch-to-zoom only) |
 | `zoomBy(factor: Float)` | Android, Desktop | iOS: Not supported |
 
 ### Text Search
@@ -157,6 +157,7 @@ data class ScrollPosition(
 ```
 
 **Platform Support:**
+
 - **Android**: Real-time updates via `setOnScrollChangeListener`
 - **iOS**: 100ms polling of `scrollView.contentOffset`
 - **Desktop**: Not supported (KCEF limitations)
@@ -204,6 +205,7 @@ data class WebViewError(
 ```
 
 **Platform-Specific Error Codes:**
+
 - **Android**: Maps to `WebViewClient` error constants (e.g., `ERROR_HOST_LOOKUP`, `ERROR_CONNECT`)
 - **iOS**: Maps to `NSURLError` codes (e.g., `NSURLErrorNotConnectedToInternet`)
 - **Desktop/Web**: Limited error information
@@ -234,7 +236,7 @@ Sealed class representing JavaScript dialog state (alert, confirm, prompt).
 sealed class JsDialogState {
     data class Alert(
         val message: String,
-        val result: (Boolean) -> Unit
+        val callback: () -> Unit
     ) : JsDialogState()
 
     data class Confirm(

--- a/docs/guides/client-configuration.md
+++ b/docs/guides/client-configuration.md
@@ -356,43 +356,33 @@ fun ErrorHandlingWebView() {
 
 ---
 
-## Migration from Old API
+## Migration from Removed API
 
-If you're using the old callback-based API, here's how to migrate:
+The old callback-based API (passing callbacks directly to `ComposeWebView`) has been removed. You must migrate to the client configuration API.
 
-### Before (Callback Parameters)
+### Before (No Longer Supported)
 
 ```kotlin
+// ❌ This will no longer compile
 ComposeWebView(
     state = state,
-    onPageStarted = { view, url, favicon ->
-        println("Started: $url")
-    },
-    onPageFinished = { view, url ->
-        println("Finished: $url")
-    },
-    onProgressChanged = { view, progress ->
-        println("Progress: $progress")
-    }
+    onPageStarted = { ... },
+    onPageFinished = { ... },
+    onProgressChanged = { ... }
 )
 ```
 
-### After (Client Configuration)
+### After (Recommended)
 
 ```kotlin
+// ✅ Use rememberWebViewClient and rememberWebChromeClient
 val client = rememberWebViewClient {
-    onPageStarted { view, url, favicon ->
-        println("Started: $url")
-    }
-    onPageFinished { view, url ->
-        println("Finished: $url")
-    }
+    onPageStarted { ... }
+    onPageFinished { ... }
 }
 
 val chromeClient = rememberWebChromeClient {
-    onProgressChanged { view, progress ->
-        println("Progress: $progress")
-    }
+    onProgressChanged { ... }
 }
 
 ComposeWebView(
@@ -402,7 +392,7 @@ ComposeWebView(
 )
 ```
 
-**Note**: Both APIs are supported. The callback parameters are still available for backward compatibility.
+**Note**: The direct callback parameters have been removed to cleaner API surface and better separation of concerns.
 
 ---
 

--- a/docs/guides/errors.md
+++ b/docs/guides/errors.md
@@ -40,14 +40,19 @@ data class WebViewError(
 You can listen for errors via the `onReceivedError` callback. This corresponds to the standard `WebViewClient.onReceivedError`.
 
 ```kotlin
+val client = rememberWebViewClient {
+    onReceivedError { view, request, error ->
+        // platform-specific types:
+        // request: PlatformWebResourceRequest?
+        // error: PlatformWebResourceError?
+
+        println("Failed to load: ${error?.description}")
+    }
+}
+
 ComposeWebView(
     url = "https://example.com",
-    onReceivedError = { webView, request, error ->
-        // request: WebResourceRequest? (platform-specific)
-        // error: WebResourceError? (platform-specific)
-
-        Log.e("WebView", "Failed to load ${request?.url}: ${error?.description}")
-    }
+    client = client
 )
 ```
 

--- a/docs/guides/features.md
+++ b/docs/guides/features.md
@@ -88,26 +88,36 @@ Capture and debug JavaScript console messages from your WebView.
 ### Usage
 
 ```kotlin
-ComposeWebView(
-    state = webViewState,
-    onConsoleMessage = { webView, message ->
-        when (message.level) {
-            ConsoleMessageLevel.ERROR -> {
-                Log.e("WebView", "[${message.sourceId}:${message.lineNumber}] ${message.message}")
+@Composable
+fun DebuggableWebView() {
+    val state = rememberSaveableWebViewState(url = "https://example.com")
+    
+    // Create handling chrome client
+    val chromeClient = rememberWebChromeClient {
+        onConsoleMessage { webView, message ->
+            when (message.level) {
+                ConsoleMessageLevel.ERROR -> {
+                    Log.e("WebView", "[${message.sourceId}:${message.lineNumber}] ${message.message}")
+                }
+                ConsoleMessageLevel.WARNING -> {
+                    Log.w("WebView", message.message)
+                }
+                ConsoleMessageLevel.LOG -> {
+                    Log.d("WebView", message.message)
+                }
+                else -> {
+                    Log.v("WebView", message.message)
+                }
             }
-            ConsoleMessageLevel.WARNING -> {
-                Log.w("WebView", message.message)
-            }
-            ConsoleMessageLevel.LOG -> {
-                Log.d("WebView", message.message)
-            }
-            else -> {
-                Log.v("WebView", message.message)
-            }
+            false // Return true to suppress default logging
         }
-        false // Return true to suppress default logging
     }
-)
+
+    ComposeWebView(
+        state = state,
+        chromeClient = chromeClient
+    )
+}
 ```
 
 ### ConsoleMessage Data Class

--- a/docs/guides/state-management.md
+++ b/docs/guides/state-management.md
@@ -77,9 +77,9 @@ The `WebViewState` object exposes reactive properties that you can observe in yo
 | `isLoading` | `Boolean` | `true` if a page is currently loading. | All platforms |
 | `loadingState` | `LoadingState` | Detailed loading progress (Initializing, Loading, Finished, Failed, Cancelled). | All platforms* |
 | `pageTitle` | `String?` | The title of the current page. | All platforms |
-| `pageIcon` | `Bitmap?` | The favicon of the current page. | Android, iOS, Desktop |
+| `pageIcon` | `PlatformBitmap?` | The favicon of the current page. | Android, iOS, Desktop |
 | `scrollPosition` | `ScrollPosition` | Current scroll position (x, y) in pixels. | Android (real-time), iOS (100ms polling), Web (CORS-limited)** |
-| `errorsForCurrentRequest` | `List<WebViewError>` | List of errors encountered during the current load. | Android, iOS, Desktop (partial), Web (limited) |
+| `errorsForCurrentRequest` | `SnapshotStateList<WebViewError>` | List of errors encountered during the current load. | Android, iOS, Desktop (partial), Web (limited) |
 | `jsDialogState` | `JsDialogState?` | Active JavaScript dialog (Alert, Confirm, Prompt). | Android, iOS |
 | `customViewState` | `CustomViewState?` | Custom view state (e.g., fullscreen video). | Android |
 
@@ -118,7 +118,7 @@ ComposeWebView(state = state)
 
 **Platform-Specific Behavior:**
 
-- **Android**: Scroll position updates in real-time via `setOnScrollChangeListener`
-- **iOS**: Scroll position updates every 100ms via polling of `scrollView.contentOffset`
-- **Desktop**: Not supported (KCEF API limitations)
-- **Web**: Only works for same-origin iframes; cross-origin iframes always report (0, 0) due to CORS
+* **Android**: Scroll position updates in real-time via `setOnScrollChangeListener`
+* **iOS**: Scroll position updates every 100ms via polling of `scrollView.contentOffset`
+* **Desktop**: Not supported (KCEF API limitations)
+* **Web**: Only works for same-origin iframes; cross-origin iframes always report (0, 0) due to CORS


### PR DESCRIPTION
- Remove legacy callback parameters from ComposeWebView API docs
- Update example codes to use rememberWebViewClient and rememberWebChromeClient
- Correct WebViewState properties types (PlatformBitmap, SnapshotStateList)
- Add missing methods to WebViewController docs (zoomIn, findNext, etc.)
- Add missing properties to WebViewSettings docs
- Fix Composable usage in Scroll Position Tracking example
- Update Migration guide in client-configuration.md