### PR TITLE
docs: comprehensive documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![API](https://img.shields.io/badge/API-24%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=24)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.2.0-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
-[![Release](https://jitpack.io/v/parkwoocheol/compose-webview.svg)](https://jitpack.io/#parkwoocheol/compose-webview)
+[![JitPack](https://jitpack.io/v/parkwoocheol/compose-webview.svg)](https://jitpack.io/#parkwoocheol/compose-webview)
+[![GitHub Release](https://img.shields.io/github/v/release/parkwoocheol/compose-webview?label=GitHub%20Packages)](https://github.com/parkwoocheol/compose-webview/packages)
 [![Compose Multiplatform](https://img.shields.io/badge/Compose%20Multiplatform-1.9.3-blue.svg)](https://github.com/JetBrains/compose-multiplatform)
 [![Documentation](https://img.shields.io/badge/docs-website-blueviolet)](https://parkwoocheol.github.io/compose-webview/)
 
@@ -70,6 +71,7 @@ Visit the documentation site for comprehensive guides, API references, and advan
  | **iOS** | `UIKitView` (WKWebView) | ✅ Stable | Full feature support (Seamless JS Bridge) |
  | **Desktop** | `SwingPanel` (CEF via KCEF) | 🚧 Experimental | **WIP**: KCEF integration is in progress. Basic browsing works, but advanced features are still being tested. |
  | **Web (JS)** | `Iframe` (DOM) | 🚧 Experimental | **WIP**: Basic navigation and JSBridge (via postMessage) are implemented but may have limitations. |
+ | **Web (WASM)** | `Iframe` (DOM) | 🚧 Experimental | **WIP**: Uses iframe with dynamic positioning. Same-origin policy restrictions apply. |
 
 ### API Support Matrix
 
@@ -289,6 +291,29 @@ dependencyResolutionManagement {
 - **Android/Desktop/Web/WASM only?** → Use **JitPack** (no auth required)
 - **iOS projects?** → Use **GitHub Packages** (required for iOS klibs)
 - **CI/CD?** → GitHub Packages supports `GITHUB_TOKEN` environment variables
+
+### Platform-Specific Artifacts
+
+When you add the dependency:
+
+```kotlin
+implementation("com.github.parkwoocheol:compose-webview:<version>")
+```
+
+The Kotlin Multiplatform Gradle plugin **automatically selects** the correct platform-specific artifact for each target:
+
+| Platform | Artifact ID | Maven Coordinates |
+|----------|-------------|-------------------|
+| **Android** | `compose-webview-android` | `com.github.parkwoocheol:compose-webview-android:<version>` |
+| **iOS (arm64)** | `compose-webview-iosarm64` | `com.github.parkwoocheol:compose-webview-iosarm64:<version>` |
+| **iOS (x64)** | `compose-webview-iosx64` | `com.github.parkwoocheol:compose-webview-iosx64:<version>` |
+| **iOS (Simulator arm64)** | `compose-webview-iossimulatorarm64` | `com.github.parkwoocheol:compose-webview-iossimulatorarm64:<version>` |
+| **Desktop (JVM)** | `compose-webview-desktop` | `com.github.parkwoocheol:compose-webview-desktop:<version>` |
+| **Web (JS)** | `compose-webview-js` | `com.github.parkwoocheol:compose-webview-js:<version>` |
+| **Web (WASM)** | `compose-webview-wasmjs` | `com.github.parkwoocheol:compose-webview-wasmjs:<version>` |
+| **Metadata** | `compose-webview` | `com.github.parkwoocheol:compose-webview:<version>` |
+
+> **Note**: You don't need to specify platform-specific artifacts manually. Just use `compose-webview` and Gradle resolves the correct artifact automatically.
 
 ## Quick Start
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -60,8 +60,8 @@ Controls the navigation and execution of the WebView.
 
 | Method | Platform Support | Notes |
 | :--- | :--- | :--- |
-| `zoomIn(): Boolean` | Android, Desktop | iOS: Not supported (pinch-to-zoom only) |
-| `zoomOut(): Boolean` | Android, Desktop | iOS: Not supported (pinch-to-zoom only) |
+| `zoomIn()` | Android, Desktop | iOS: Not supported (pinch-to-zoom only) |
+| `zoomOut()` | Android, Desktop | iOS: Not supported (pinch-to-zoom only) |
 | `zoomBy(factor: Float)` | Android, Desktop | iOS: Not supported |
 
 ### Text Search
@@ -85,8 +85,8 @@ Controls the navigation and execution of the WebView.
 
 | Method | Platform Support | Notes |
 | :--- | :--- | :--- |
-| `clearCache(includeDiskFiles: Boolean)` | Android, iOS, Desktop | Clear WebView cache |
-| `clearHistory()` | Android, iOS, Desktop | Clear navigation history |
+| `clearCache()` | Android | Clear WebView cache |
+| `clearHistory()` | Android | Clear navigation history |
 | `clearSslPreferences()` | Android | Clear SSL certificate decisions |
 | `clearFormData()` | Android | Clear form autofill data |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,9 +14,14 @@ Before you begin, ensure your project meets the following requirements:
 
 ## Installation
 
-Artifacts are distributed via **JitPack**.
+This library is available from **JitPack** and **GitHub Packages**. Choose based on your platform needs:
 
-### Add the Repository
+| Repository | Best For | Authentication |
+|-----------|---------|---------------|
+| **JitPack** | Android, Desktop, Web, WASM | None required |
+| **GitHub Packages** | **iOS projects** (also supports all other platforms) | GitHub token required |
+
+### Option 1: JitPack (Recommended for non-iOS projects)
 
 1. **Add the JitPack repository**
 
@@ -40,6 +45,42 @@ Artifacts are distributed via **JitPack**.
                 google()
                 mavenCentral()
                 maven { url = "https://jitpack.io" }
+            }
+        }
+        ```
+
+### Option 2: GitHub Packages (Required for iOS)
+
+GitHub Packages includes **iOS klib artifacts** built on macOS. JitPack builds on Linux and cannot produce these.
+
+1. **Create a GitHub Personal Access Token (PAT)**
+    * Go to [GitHub Settings → Developer settings → Personal access tokens](https://github.com/settings/tokens)
+    * Click "Generate new token (classic)"
+    * Scopes: Select `read:packages`
+
+2. **Configure credentials** (`~/.gradle/gradle.properties`):
+
+    ```properties
+    gpr.user=YOUR_GITHUB_USERNAME
+    gpr.key=YOUR_GITHUB_PAT
+    ```
+
+3. **Add GitHub Packages repository**
+
+    === "Kotlin (`settings.gradle.kts`)"
+
+        ```kotlin
+        dependencyResolutionManagement {
+            repositories {
+                google()
+                mavenCentral()
+                maven {
+                    url = uri("https://maven.pkg.github.com/parkwoocheol/compose-webview")
+                    credentials {
+                        username = findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
+                        password = findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
+                    }
+                }
             }
         }
         ```
@@ -72,10 +113,23 @@ Artifacts are distributed via **JitPack**.
         }
         ```
 
-The dependency snippet is identical in both Kotlin and Groovy DSL examples above.
-
 !!! tip "Latest Version"
     Check [GitHub Releases](https://github.com/parkwoocheol/compose-webview/releases) or the [JitPack badge](https://jitpack.io/#parkwoocheol/compose-webview) for the current version number.
+
+### Platform-Specific Artifacts
+
+The Kotlin Multiplatform Gradle plugin **automatically selects** the correct artifact:
+
+| Platform | Artifact ID |
+|----------|-------------|
+| **Android** | `compose-webview-android` |
+| **iOS (arm64)** | `compose-webview-iosarm64` |
+| **iOS (Simulator arm64)** | `compose-webview-iossimulatorarm64` |
+| **Desktop (JVM)** | `compose-webview-desktop` |
+| **Web (JS)** | `compose-webview-js` |
+| **Web (WASM)** | `compose-webview-wasmjs` |
+
+> **Note**: You don't need to specify platform-specific artifacts manually. Just use `compose-webview` and Gradle resolves the correct artifact automatically.
 
 ---
 

--- a/docs/guides/features.md
+++ b/docs/guides/features.md
@@ -6,17 +6,17 @@ This guide covers advanced capabilities of `compose-webview` including WebView C
 
 ## Platform Support Matrix
 
-| Feature | Android | iOS | Desktop | Web |
-|---------|:-------:|:---:|:-------:|:---:|
-| WebViewSettings Configuration | ✅ | ⚠️ | ⚠️ | ❌ |
-| Console Message Debugging | ✅ | ✅ | ❌ | ❌ |
-| Scroll Position Tracking | ✅ | ✅ | ❌ | ⚠️ |
-| Loading State with Progress | ✅ | ✅ | ⚠️ | ⚠️ |
-| Typed Error Handling | ✅ | ✅ | ⚠️ | ⚠️ |
-| File Uploads | ✅ | ✅ | ❌ | ❌ |
-| Downloads | ✅ | ⚠️ | ❌ | ❌ |
-| Custom View (Fullscreen) | ✅ | ❌ | ❌ | ❌ |
-| JS Dialogs (Alert/Confirm/Prompt) | ✅ | ✅ | ❌ | ❌ |
+| Feature | Android | iOS | Desktop | Web (JS) | Web (WASM) |
+|---------|:-------:|:---:|:-------:|:--------:|:----------:|
+| WebViewSettings Configuration | ✅ | ⚠️ | ⚠️ | ❌ | ❌ |
+| Console Message Debugging | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Scroll Position Tracking | ✅ | ✅ | ❌ | ⚠️ | ⚠️ |
+| Loading State with Progress | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| Typed Error Handling | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| File Uploads | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Downloads | ✅ | ⚠️ | ❌ | ❌ | ❌ |
+| Custom View (Fullscreen) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| JS Dialogs (Alert/Confirm/Prompt) | ✅ | ✅ | ❌ | ❌ | ❌ |
 
 **Legend**: ✅ Full Support | ⚠️ Partial/Limited | ❌ Not Supported
 
@@ -46,14 +46,14 @@ ComposeWebView(
 
 ### Available Settings
 
-| Setting | Android | iOS | Desktop | Web | Notes |
-|---------|:-------:|:---:|:-------:|:---:|-------|
-| `userAgent` | ✅ | ✅ | ✅ | ❌ | Custom user agent string |
-| `javaScriptEnabled` | ✅ | ✅* | ✅ | ❌ | *iOS: Always enabled |
-| `domStorageEnabled` | ✅ | ✅ | ⚠️ | ❌ | localStorage/sessionStorage |
-| `cacheMode` | ✅ | ⚠️ | ⚠️ | ❌ | Cache behavior control |
-| `supportZoom` | ✅ | ⚠️** | ✅ | ❌ | **iOS: Pinch-to-zoom only |
-| `mediaPlaybackRequiresUserAction` | ✅ | ✅ | ⚠️ | ❌ | Autoplay control |
+| Setting | Android | iOS | Desktop | Web (JS) | Web (WASM) | Notes |
+|---------|:-------:|:---:|:-------:|:--------:|:----------:|-------|
+| `userAgent` | ✅ | ✅ | ✅ | ❌ | ❌ | Custom user agent string |
+| `javaScriptEnabled` | ✅ | ✅* | ✅ | ❌ | ❌ | *iOS: Always enabled |
+| `domStorageEnabled` | ✅ | ✅ | ⚠️ | ❌ | ❌ | localStorage/sessionStorage |
+| `cacheMode` | ✅ | ⚠️ | ⚠️ | ❌ | ❌ | Cache behavior control |
+| `supportZoom` | ✅ | ⚠️** | ✅ | ❌ | ❌ | **iOS: Pinch-to-zoom only |
+| `mediaPlaybackRequiresUserAction` | ✅ | ✅ | ⚠️ | ❌ | ❌ | Autoplay control |
 
 !!! info "Platform-Specific Behavior"
     - **iOS**: JavaScript is always enabled and cannot be disabled. The `javaScriptEnabled` setting is ignored.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ It provides a unified API to control WebViews across **Android**, **iOS**, **Des
 | **iOS** | `UIKitView` (WKWebView) | :white_check_mark: Stable | Full feature support (Seamless JS Bridge) |
 | **Desktop** | `SwingPanel` (CEF via KCEF) | :construction: Experimental | **WIP**: Basic browsing works. KCEF integration in progress. |
 | **Web (JS)** | `Iframe` (DOM) | :construction: Experimental | **WIP**: Basic navigation and `postMessage` bridge. |
+| **Web (WASM)** | `Iframe` (DOM) | :construction: Experimental | **WIP**: Uses iframe with dynamic positioning. Same-origin policy restrictions. |
 
 !!! note "Project Focus: Mobile Productivity"
     This library is optimized for **Mobile (Android & iOS)** development. While Desktop and Web are supported, they are currently experimental. If you need a battle-tested solution primarily for Desktop/Web, other libraries might be a better fit.


### PR DESCRIPTION
- Add GitHub Release badge alongside JitPack badge
- Add WASM platform to all support tables
- Document 8 platform-specific artifacts with KMP auto-selection
- Sync GitHub Packages installation guide to docs/getting-started.md