### PR TITLE
fix: add missing actual declarations for configureAndroidContextMenu

### DIFF
--- a/sample/shared/src/desktopMain/kotlin/com/parkwoocheol/sample/composewebview/ui/screens/ContextMenuHelper.desktop.kt
+++ b/sample/shared/src/desktopMain/kotlin/com/parkwoocheol/sample/composewebview/ui/screens/ContextMenuHelper.desktop.kt
@@ -1,0 +1,11 @@
+package com.parkwoocheol.sample.composewebview.ui.screens
+
+import com.parkwoocheol.composewebview.PlatformActionModeCallback
+import com.parkwoocheol.composewebview.WebView
+
+actual fun configureAndroidContextMenu(
+    webView: WebView,
+    callback: PlatformActionModeCallback?,
+): PlatformActionModeCallback? {
+    return null
+}

--- a/sample/shared/src/wasmJsMain/kotlin/com/parkwoocheol/sample/composewebview/ui/screens/ContextMenuHelper.wasmJs.kt
+++ b/sample/shared/src/wasmJsMain/kotlin/com/parkwoocheol/sample/composewebview/ui/screens/ContextMenuHelper.wasmJs.kt
@@ -1,0 +1,11 @@
+package com.parkwoocheol.sample.composewebview.ui.screens
+
+import com.parkwoocheol.composewebview.PlatformActionModeCallback
+import com.parkwoocheol.composewebview.WebView
+
+actual fun configureAndroidContextMenu(
+    webView: WebView,
+    callback: PlatformActionModeCallback?,
+): PlatformActionModeCallback? {
+    return null
+}


### PR DESCRIPTION
Add Desktop and WasmJs platform implementations of configureAndroidContextMenu to fix JitPack build error. Both platforms return null as they don't support Android-specific context menu functionality.