### PR TITLE
Desktop: migrate to JCEF 141, fix macOS module-access runtime issues, and align docs

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -79,6 +79,27 @@ excluded_tools: []
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
-
+# the name by which the project can be referenced within Serena
 project_name: "compose-webview"
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
 included_optional_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []

--- a/README.md
+++ b/README.md
@@ -72,9 +72,28 @@ Visit the documentation site for comprehensive guides, API references, and advan
  |----------|----------------|--------|------|
  | **Android** | `AndroidView` (WebView) | ✅ Stable | Full feature support |
  | **iOS** | `UIKitView` (WKWebView) | ✅ Stable | Full feature support (Seamless JS Bridge) |
- | **Desktop** | `SwingPanel` (CEF via KCEF) | 🚧 Experimental | **WIP**: KCEF integration is in progress. Basic browsing works, but advanced features are still being tested. |
+| **Desktop** | `SwingPanel` (CEF via JCEF) | 🚧 Experimental | **WIP**: JCEF integration is in progress. Basic browsing works, but advanced features are still being tested. |
  | **Web (JS)** | `Iframe` (DOM) | 🚧 Experimental | **WIP**: Basic navigation and JSBridge (via postMessage) are implemented but may have limitations. |
  | **Web (WASM)** | `Iframe` (DOM) | 🚧 Experimental | **WIP**: Uses iframe with dynamic positioning. Same-origin policy restrictions apply. |
+
+### Desktop (macOS) Troubleshooting
+
+If you see `IllegalAccessError` with `sun.awt`, `sun.lwawt`, or `sun.lwawt.macosx` while running JCEF on macOS, add JVM module options:
+
+```kotlin
+compose.desktop {
+    application {
+        jvmArgs += listOf(
+            "--add-exports=java.desktop/sun.awt=ALL-UNNAMED",
+            "--add-opens=java.desktop/sun.awt=ALL-UNNAMED",
+            "--add-exports=java.desktop/sun.lwawt=ALL-UNNAMED",
+            "--add-opens=java.desktop/sun.lwawt=ALL-UNNAMED",
+            "--add-exports=java.desktop/sun.lwawt.macosx=ALL-UNNAMED",
+            "--add-opens=java.desktop/sun.lwawt.macosx=ALL-UNNAMED",
+        )
+    }
+}
+```
 
 ### API Support Matrix
 

--- a/compose-webview/build.gradle.kts
+++ b/compose-webview/build.gradle.kts
@@ -92,7 +92,7 @@ kotlin {
         getByName("desktopMain") {
             dependencies {
                 implementation(compose.desktop.currentOs)
-                implementation(libs.kcef)
+                implementation(libs.jcef)
             }
         }
 

--- a/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewController.kt
+++ b/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewController.kt
@@ -126,7 +126,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.loadUrl | HTTP headers supported |
      * | iOS      | ✅ Full | WKWebView.load | HTTP headers supported |
-     * | Desktop  | ✅ Partial | KCEF loadURL | HTTP headers not supported |
+     * | Desktop  | ✅ Partial | JCEF loadURL | HTTP headers not supported |
      * | Web      | ✅ Partial | iframe src | HTTP headers not supported |
      *
      * @param url The URL to load.
@@ -149,7 +149,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.loadDataWithBaseURL | Supports all parameters |
      * | iOS      | ✅ Full | WKWebView.loadHTMLString | Supports baseURL |
-     * | Desktop  | ✅ Full | KCEF loadHTML | Supports HTML loading |
+     * | Desktop  | ✅ Full | JCEF loadHTML | Supports HTML loading |
      * | Web      | ⚠️ Limited | iframe srcdoc/data URI | Limited baseURL support, CORS restrictions |
      *
      * @param html The HTML content string.
@@ -209,7 +209,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.evaluateJavascript | Async with callback |
      * | iOS      | ✅ Full | WKWebView.evaluateJavaScript | Async with callback |
-     * | Desktop  | ✅ Full | KCEF executeJavaScript | Async with callback |
+     * | Desktop  | ✅ Full | JCEF executeJavaScript | Async with callback |
      * | Web      | ⚠️ Limited | contentWindow.eval | CORS restricted - same-origin only |
      *
      * @param script The JavaScript to evaluate.
@@ -232,7 +232,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.goBack | Native history navigation |
      * | iOS      | ✅ Full | WKWebView.goBack | Native history navigation |
-     * | Desktop  | ✅ Full | KCEF goBack | Native history navigation |
+     * | Desktop  | ✅ Full | JCEF goBack | Native history navigation |
      * | Web      | ⚠️ Limited | history.back | CORS restricted - same-origin only |
      */
     fun navigateBack() {
@@ -247,7 +247,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.goForward | Native history navigation |
      * | iOS      | ✅ Full | WKWebView.goForward | Native history navigation |
-     * | Desktop  | ✅ Full | KCEF goForward | Native history navigation |
+     * | Desktop  | ✅ Full | JCEF goForward | Native history navigation |
      * | Web      | ⚠️ Limited | history.forward | CORS restricted - same-origin only |
      */
     fun navigateForward() {
@@ -262,7 +262,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.reload | Reloads from network or cache |
      * | iOS      | ✅ Full | WKWebView.reload | Reloads from network or cache |
-     * | Desktop  | ✅ Full | KCEF reload | Reloads from network or cache |
+     * | Desktop  | ✅ Full | JCEF reload | Reloads from network or cache |
      * | Web      | ⚠️ Limited | location.reload | CORS restricted - same-origin only |
      */
     fun reload() {
@@ -277,7 +277,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.stopLoading | Stops page loading immediately |
      * | iOS      | ✅ Full | WKWebView.stopLoading | Stops page loading immediately |
-     * | Desktop  | ✅ Full | KCEF stop | Stops page loading immediately |
+     * | Desktop  | ✅ Full | JCEF stop | Stops page loading immediately |
      * | Web      | ⚠️ Limited | window.stop | CORS restricted - same-origin only |
      */
     fun stopLoading() {
@@ -292,7 +292,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.zoomBy | Multiplies current zoom level |
      * | iOS      | ❌ Not supported | - | WKWebView doesn't support programmatic zoom |
-     * | Desktop  | ✅ Full | KCEF setZoomLevel | Sets absolute zoom level |
+     * | Desktop  | ✅ Full | JCEF setZoomLevel | Sets absolute zoom level |
      * | Web      | ❌ Not supported | - | Browser controlled |
      *
      * @param zoomFactor The zoom factor to apply (e.g., 1.5 for 150% zoom).
@@ -309,7 +309,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.zoomIn | Native zoom controls |
      * | iOS      | ❌ Not supported | - | WKWebView doesn't support programmatic zoom |
-     * | Desktop  | ✅ Full | KCEF zoomIn | Native zoom controls |
+     * | Desktop  | ✅ Full | JCEF zoomIn | Native zoom controls |
      * | Web      | ❌ Not supported | - | Browser controlled |
      */
     fun zoomIn() {
@@ -324,7 +324,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.zoomOut | Native zoom controls |
      * | iOS      | ❌ Not supported | - | WKWebView doesn't support programmatic zoom |
-     * | Desktop  | ✅ Full | KCEF zoomOut | Native zoom controls |
+     * | Desktop  | ✅ Full | JCEF zoomOut | Native zoom controls |
      * | Web      | ❌ Not supported | - | Browser controlled |
      */
     fun zoomOut() {
@@ -341,7 +341,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.findAllAsync | Highlights all matches |
      * | iOS      | ❌ Not supported | - | WKWebView lacks find API |
-     * | Desktop  | ❌ Not supported | - | KCEF find API not exposed |
+     * | Desktop  | ❌ Not supported | - | JCEF find API not exposed |
      * | Web      | ❌ Not supported | - | No cross-browser standard |
      *
      * @param find The string to find.
@@ -360,7 +360,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.findNext | Navigates to next match |
      * | iOS      | ❌ Not supported | - | WKWebView lacks find API |
-     * | Desktop  | ❌ Not supported | - | KCEF find API not exposed |
+     * | Desktop  | ❌ Not supported | - | JCEF find API not exposed |
      * | Web      | ❌ Not supported | - | No cross-browser standard |
      *
      * @param forward Whether to search forward (true) or backward (false).
@@ -377,7 +377,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.clearMatches | Removes highlighting |
      * | iOS      | ❌ Not supported | - | WKWebView lacks find API |
-     * | Desktop  | ❌ Not supported | - | KCEF find API not exposed |
+     * | Desktop  | ❌ Not supported | - | JCEF find API not exposed |
      * | Web      | ❌ Not supported | - | No cross-browser standard |
      */
     fun clearMatches() {
@@ -392,7 +392,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.clearCache | Clears disk and memory cache |
      * | iOS      | ❌ Not supported | - | Use WKWebsiteDataStore separately |
-     * | Desktop  | ❌ Not supported | - | KCEF cache management separate |
+     * | Desktop  | ❌ Not supported | - | JCEF cache management separate |
      * | Web      | ❌ Not supported | - | Browser controlled |
      */
     fun clearCache() {
@@ -407,7 +407,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.clearHistory | Clears navigation history |
      * | iOS      | ❌ Not supported | - | WKWebView history is read-only |
-     * | Desktop  | ❌ Not supported | - | KCEF history not exposed |
+     * | Desktop  | ❌ Not supported | - | JCEF history not exposed |
      * | Web      | ❌ Not supported | - | Browser controlled |
      */
     fun clearHistory() {
@@ -422,7 +422,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.clearSslPreferences | Clears SSL error exceptions |
      * | iOS      | ❌ Not supported | - | WKWebView doesn't store SSL preferences |
-     * | Desktop  | ❌ Not supported | - | KCEF SSL handling different |
+     * | Desktop  | ❌ Not supported | - | JCEF SSL handling different |
      * | Web      | ❌ Not supported | - | Browser controlled |
      */
     fun clearSslPreferences() {
@@ -437,7 +437,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.clearFormData | Clears autofill data |
      * | iOS      | ❌ Not supported | - | WKWebView form data separate |
-     * | Desktop  | ❌ Not supported | - | KCEF form data separate |
+     * | Desktop  | ❌ Not supported | - | JCEF form data separate |
      * | Web      | ❌ Not supported | - | Browser controlled |
      */
     fun clearFormData() {
@@ -452,7 +452,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.pageUp | Scrolls up by viewport height |
      * | iOS      | ⚠️ Partial | scrollBy(viewportHeight) | Implemented via scrollBy |
-     * | Desktop  | ❌ Not supported | - | KCEF scroll API not exposed |
+     * | Desktop  | ❌ Not supported | - | JCEF scroll API not exposed |
      * | Web      | ⚠️ Partial | scrollBy(viewportHeight) | Implemented via scrollBy |
      *
      * @param top If true, scrolls to the top of the page.
@@ -469,7 +469,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.pageDown | Scrolls down by viewport height |
      * | iOS      | ⚠️ Partial | scrollBy(viewportHeight) | Implemented via scrollBy |
-     * | Desktop  | ❌ Not supported | - | KCEF scroll API not exposed |
+     * | Desktop  | ❌ Not supported | - | JCEF scroll API not exposed |
      * | Web      | ⚠️ Partial | scrollBy(viewportHeight) | Implemented via scrollBy |
      *
      * @param bottom If true, scrolls to the bottom of the page.
@@ -486,7 +486,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.scrollTo | Scrolls to absolute position |
      * | iOS      | ✅ Full | scrollView.setContentOffset | Scrolls to absolute position |
-     * | Desktop  | ❌ Not supported | - | KCEF scroll API not exposed |
+     * | Desktop  | ❌ Not supported | - | JCEF scroll API not exposed |
      * | Web      | ✅ Full | scrollTo() | Scrolls to absolute position |
      *
      * @param x The x-coordinate in pixels.
@@ -507,7 +507,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.scrollBy | Scrolls relative to current position |
      * | iOS      | ✅ Full | scrollView.contentOffset | Scrolls relative to current position |
-     * | Desktop  | ❌ Not supported | - | KCEF scroll API not exposed |
+     * | Desktop  | ❌ Not supported | - | JCEF scroll API not exposed |
      * | Web      | ✅ Full | scrollBy() | Scrolls relative to current position |
      *
      * @param x The x-offset in pixels.
@@ -528,7 +528,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * |----------|---------|----------------|-------|
      * | Android  | ✅ Full | WebView.saveWebArchive | Saves as .mht file |
      * | iOS      | ❌ Not supported | - | WKWebView doesn't support web archives |
-     * | Desktop  | ❌ Not supported | - | KCEF archive API not exposed |
+     * | Desktop  | ❌ Not supported | - | JCEF archive API not exposed |
      * | Web      | ❌ Not supported | - | Browser controlled |
      *
      * @param filename The filename to save the archive to (Android only).

--- a/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewState.kt
+++ b/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewState.kt
@@ -129,7 +129,7 @@ class WebViewState(webContent: WebContent) {
      * |----------|---------|-------|
      * | Android  | ✅ Full | WebChromeClient.onReceivedIcon |
      * | iOS      | ⚠️ Limited | Not directly available, requires custom handling |
-     * | Desktop  | ⚠️ Limited | KCEF favicon handling limited |
+     * | Desktop  | ⚠️ Limited | JCEF favicon handling limited |
      * | Web      | ⚠️ Limited | CORS restrictions apply |
      */
     var pageIcon: PlatformBitmap? by mutableStateOf(null)
@@ -151,7 +151,7 @@ class WebViewState(webContent: WebContent) {
      * |----------|---------|-------|
      * | Android  | ✅ Full | WebChromeClient callbacks |
      * | iOS      | ✅ Full | WKUIDelegate callbacks |
-     * | Desktop  | ❌ Not supported | KCEF dialog handling different |
+     * | Desktop  | ❌ Not supported | JCEF dialog handling different |
      * | Web      | ❌ Not supported | Browser handles dialogs natively |
      */
     var jsDialogState: JsDialogState? by mutableStateOf(null)
@@ -166,7 +166,7 @@ class WebViewState(webContent: WebContent) {
      * |----------|---------|-------|
      * | Android  | ✅ Full | WebChromeClient.onShowCustomView |
      * | iOS      | ⚠️ Limited | Emits state when WKWebView enters native fullscreen |
-     * | Desktop  | ❌ Not supported | KCEF handles fullscreen separately |
+     * | Desktop  | ❌ Not supported | JCEF handles fullscreen separately |
      * | Web      | ❌ Not supported | Browser handles fullscreen natively |
      */
     var customViewState: CustomViewState? by mutableStateOf(null)

--- a/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.desktop.kt
+++ b/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.desktop.kt
@@ -7,17 +7,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.SwingPanel
 import com.parkwoocheol.composewebview.client.ComposeWebChromeClient
 import com.parkwoocheol.composewebview.client.ComposeWebViewClient
-import dev.datlag.kcef.KCEF
-import dev.datlag.kcef.KCEFBrowser
+import kotlinx.coroutines.flow.collectLatest
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
-import org.cef.browser.CefRendering
 import org.cef.handler.CefDisplayHandlerAdapter
 import org.cef.handler.CefLoadHandlerAdapter
+import org.cef.handler.CefRequestHandlerAdapter
 import java.awt.BorderLayout
 import javax.swing.JLabel
 import javax.swing.JPanel
@@ -96,145 +96,184 @@ internal actual fun ComposeWebViewImpl(
     onFindResultReceived: ((Int, Int, Boolean) -> Unit)?,
     onStartActionMode: ((WebView, PlatformActionModeCallback?) -> PlatformActionModeCallback?)?,
 ) {
+    client.webViewState = state
+    client.webViewController = controller
+
     var initialized by remember { mutableStateOf(false) }
-    var browser: KCEFBrowser? by remember { mutableStateOf(null) }
+    var initializationError by remember { mutableStateOf<Throwable?>(null) }
+    var webView: DesktopWebView? by remember { mutableStateOf(null) }
 
     LaunchedEffect(Unit) {
-        // Initialize KCEF (downloads binaries if needed)
-        KCEF.init(builder = {
-            // Apply WebView settings to CEF
-            // Note: CEF has limited runtime configuration
-            // Most settings need to be applied at builder time
-            if (!settings.javaScriptEnabled) {
-                addArgs("--disable-javascript")
-            }
-
-            settings.userAgent?.let { ua ->
-                addArgs("--user-agent=$ua")
-            }
-
-            // Apply other settings as CEF arguments if possible
-        }, onError = {
-            it?.printStackTrace()
-        }, onRestartRequired = {
-            // Handle restart
-        })
-        initialized = true
+        runCatching {
+            DesktopCefRuntime.initialize(settings)
+        }.onSuccess {
+            initialized = true
+        }.onFailure { throwable ->
+            initializationError = throwable
+        }
     }
 
     if (initialized) {
         DisposableEffect(Unit) {
-            val kcefClient = KCEF.newClientOrNullBlocking()
+            val cefClient = DesktopCefRuntime.createClient()
 
-            // Add Load Handler
-            kcefClient?.addLoadHandler(
-                object : CefLoadHandlerAdapter() {
-                    override fun onLoadingStateChange(
-                        browser: CefBrowser?,
-                        isLoading: Boolean,
-                        canGoBack: Boolean,
-                        canGoForward: Boolean,
-                    ) {
-                        if (isLoading) {
-                            state.loadingState = LoadingState.Loading(0f)
-                            // We don't have a direct "onPageStarted" equivalent with URL here easily without CefDisplayHandler
-                            // But we can approximate.
-                        } else {
-                            state.loadingState = LoadingState.Finished
-                            // Trigger onPageFinished
-                            browser?.let {
-                                // We need a way to get the WebView instance here, but it's created inside the factory.
-                                // For now, we update state directly which is what the default client does.
-                                // To support custom clients, we should ideally call client.onPageFinished.
-                                // However, we don't have the WebView instance yet or it's hard to access.
-                                // We will rely on state updates for now.
+            if (cefClient == null) {
+                initializationError = IllegalStateException("Failed to create JCEF client.")
+                onDispose { }
+            } else {
+                var activeView: DesktopWebView? = null
+
+                var lastLoadingState = false
+
+                // Add Load Handler
+                cefClient.addLoadHandler(
+                    object : CefLoadHandlerAdapter() {
+                        override fun onLoadingStateChange(
+                            browser: CefBrowser?,
+                            isLoading: Boolean,
+                            canGoBack: Boolean,
+                            canGoForward: Boolean,
+                        ) {
+                            if (isLoading && !lastLoadingState) {
+                                state.loadingState = LoadingState.Loading(0f)
+                                state.lastLoadedUrl = browser?.url
+                                client.onPageStarted(activeView, browser?.url, null)
+                            } else {
+                                state.loadingState = LoadingState.Finished
+                                if (lastLoadingState) {
+                                    client.onPageFinished(activeView, browser?.url)
+                                }
                             }
+                            lastLoadingState = isLoading
+                            controller.canGoBack = canGoBack
+                            controller.canGoForward = canGoForward
                         }
-                        controller.canGoBack = canGoBack
-                        controller.canGoForward = canGoForward
-                    }
-                },
-            )
+                    },
+                )
 
-            // Add Request Handler for shouldOverrideUrlLoading
-            kcefClient?.addRequestHandler(
-                object : org.cef.handler.CefRequestHandlerAdapter() {
-                    override fun onBeforeBrowse(
-                        browser: CefBrowser?,
-                        frame: CefFrame?,
-                        request: org.cef.network.CefRequest?,
-                        user_gesture: Boolean,
-                        is_redirect: Boolean,
-                    ): Boolean {
-                        if (request == null) return false
-                        val platformRequest =
-                            PlatformWebResourceRequest(
-                                url = request.url,
-                                method = request.method,
-                                // Headers not easily accessible here in this signature
-                                headers = emptyMap(),
-                                // Simplified
-                                isForMainFrame = true,
-                            )
-                        // If client returns true, cancel navigation (return true)
-                        // We need to pass a WebView instance. Since we don't have the wrapper easily, pass null for now
-                        // or refactor to hold reference.
-                        // For the sample app's CustomClient, it just checks the URL.
-                        return client.shouldOverrideUrlLoading(null, platformRequest)
-                    }
-                },
-            )
+                // Add Request Handler for shouldOverrideUrlLoading
+                cefClient.addRequestHandler(
+                    object : CefRequestHandlerAdapter() {
+                        override fun onBeforeBrowse(
+                            browser: CefBrowser?,
+                            frame: CefFrame?,
+                            request: org.cef.network.CefRequest?,
+                            user_gesture: Boolean,
+                            is_redirect: Boolean,
+                        ): Boolean {
+                            if (request == null) return false
+                            val platformRequest =
+                                PlatformWebResourceRequest(
+                                    url = request.url,
+                                    method = request.method,
+                                    headers = emptyMap(),
+                                    isForMainFrame = true,
+                                )
+                            return client.shouldOverrideUrlLoading(activeView, platformRequest)
+                        }
+                    },
+                )
 
-            // Add Display Handler
-            kcefClient?.addDisplayHandler(
-                object : CefDisplayHandlerAdapter() {
-                    override fun onAddressChange(
-                        browser: CefBrowser?,
-                        frame: CefFrame?,
-                        url: String?,
-                    ) {
-                        state.lastLoadedUrl = url
+                // Add Display Handler
+                cefClient.addDisplayHandler(
+                    object : CefDisplayHandlerAdapter() {
+                        override fun onAddressChange(
+                            browser: CefBrowser?,
+                            frame: CefFrame?,
+                            url: String?,
+                        ) {
+                            state.lastLoadedUrl = url
+                        }
+
+                        override fun onTitleChange(
+                            browser: CefBrowser?,
+                            title: String?,
+                        ) {
+                            state.pageTitle = title
+                        }
+                    },
+                )
+
+                // Determine initial URL from state
+                val initialUrl =
+                    when (val content = state.content) {
+                        is WebContent.Url -> content.url
+                        is WebContent.Data -> "about:blank"
+                        is WebContent.Post -> content.url
+                        is WebContent.NavigatorOnly -> "about:blank"
                     }
 
-                    override fun onTitleChange(
-                        browser: CefBrowser?,
-                        title: String?,
-                    ) {
-                        state.pageTitle = title
-                    }
-                },
-            )
-
-            // Determine initial URL from state
-            val initialUrl =
-                when (val content = state.content) {
-                    is WebContent.Url -> content.url
-                    is WebContent.Data -> "about:blank" // TODO: Handle data loading
-                    is WebContent.Post -> content.url
-                    is WebContent.NavigatorOnly -> "about:blank"
+                val browser = cefClient.createBrowser(initialUrl, false, false)
+                browser.createImmediately()
+                if (initialUrl.isNotBlank()) {
+                    browser.loadURL(initialUrl)
                 }
+                val createdView = DesktopWebView(browser, cefClient)
+                createdView.platformJavaScriptEnabled = settings.javaScriptEnabled
+                createdView.platformDomStorageEnabled = settings.domStorageEnabled
+                createdView.platformSupportZoom = settings.supportZoom
+                createdView.platformBuiltInZoomControls = settings.supportZoom
+                createdView.platformDisplayZoomControls = false
+                activeView = createdView
+                webView = createdView
+                state.webView = createdView
 
-            val newBrowser = kcefClient?.createBrowser(initialUrl, CefRendering.DEFAULT, false)
-            browser = newBrowser
+                javaScriptInterfaces.forEach { (name, obj) ->
+                    createdView.platformAddJavascriptInterface(obj, name)
+                }
+                onCreated(createdView)
+                jsBridge?.attach(createdView)
 
-            onDispose {
-                browser?.dispose()
+                onDispose {
+                    activeView?.let(onDispose)
+                    if (state.webView === activeView) {
+                        state.webView = null
+                    }
+                    webView = null
+                    browser.close(true)
+                    cefClient.dispose()
+                }
             }
         }
 
-        if (browser != null) {
+        if (webView != null) {
+            LaunchedEffect(webView, controller) {
+                controller.handleNavigationEvents(webView!!)
+            }
+
+            LaunchedEffect(webView) {
+                snapshotFlow { state.content }.collectLatest { content ->
+                    val activeWebView = webView ?: return@collectLatest
+                    when (content) {
+                        is WebContent.Url -> {
+                            if (content.url.isNotEmpty() && state.lastLoadedUrl != content.url) {
+                                activeWebView.platformLoadUrl(content.url, content.additionalHttpHeaders)
+                            }
+                        }
+
+                        is WebContent.Data -> {
+                            activeWebView.platformLoadDataWithBaseURL(
+                                content.baseUrl,
+                                content.data,
+                                content.mimeType,
+                                content.encoding,
+                                content.historyUrl,
+                            )
+                        }
+
+                        is WebContent.Post -> {
+                            activeWebView.platformPostUrl(content.url, content.postData)
+                        }
+
+                        is WebContent.NavigatorOnly -> Unit
+                    }
+                }
+            }
+
             SwingPanel(
                 modifier = modifier,
-                factory = {
-                    val webView = DesktopWebView(browser!!)
-                    onCreated(webView)
-                    jsBridge?.attach(webView)
-                    webView
-                },
-                update = {
-                    // Handle state updates if needed, e.g. loading new URL from state
-                    // For now, we rely on controller for navigation
-                },
+                factory = { webView!! },
+                update = { },
             )
 
             // Inject JS Bridge script when page finishes loading
@@ -246,7 +285,7 @@ internal actual fun ComposeWebViewImpl(
                 }
             }
         } else {
-            // Fallback to JEditorPane if CEF fails
+            // Fallback if browser creation fails
             SwingPanel(
                 modifier = modifier,
                 factory = {
@@ -254,7 +293,7 @@ internal actual fun ComposeWebViewImpl(
                         javax.swing.JEditorPane().apply {
                             isEditable = false
                             contentType = "text/html"
-                            text = "<html><body><h1>CEF Initialization Failed</h1><p>Could not create CEF browser.</p></body></html>"
+                            text = "<html><body><h1>JCEF Initialization Failed</h1><p>Could not create JCEF browser.</p></body></html>"
                         }
                     val scrollPane = javax.swing.JScrollPane(jEditorPane)
                     val panel = JPanel(BorderLayout())
@@ -263,14 +302,21 @@ internal actual fun ComposeWebViewImpl(
                 },
             )
         }
+    } else if (initializationError != null) {
+        errorContent(
+            listOf(
+                WebViewError(
+                    description = initializationError?.message ?: "Desktop WebView initialization failed",
+                ),
+            ),
+        )
     } else {
-        // Show loading content while initializing CEF (downloading binaries)
+        // Show loading content while initializing JCEF runtime.
         loadingContent()
-        // Optional: Show a SwingPanel with "Initializing..." text if loadingContent is empty
         SwingPanel(
             modifier = modifier,
             factory = {
-                val label = JLabel("Initializing WebView (Downloading CEF)...")
+                val label = JLabel("Initializing WebView (JCEF)...")
                 label.horizontalAlignment = JLabel.CENTER
                 val panel = JPanel(BorderLayout())
                 panel.add(label, BorderLayout.CENTER)

--- a/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/DesktopCefRuntime.desktop.kt
+++ b/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/DesktopCefRuntime.desktop.kt
@@ -1,0 +1,40 @@
+package com.parkwoocheol.composewebview
+
+import me.friwi.jcefmaven.CefAppBuilder
+import org.cef.CefApp
+import org.cef.CefClient
+import java.io.File
+
+internal object DesktopCefRuntime {
+    @Volatile
+    private var app: CefApp? = null
+    private val lock = Any()
+
+    fun initialize(settings: WebViewSettings) {
+        if (app != null) return
+
+        synchronized(lock) {
+            if (app != null) return
+
+            val args = mutableListOf<String>()
+            if (!settings.javaScriptEnabled) {
+                args += "--disable-javascript"
+            }
+            settings.userAgent?.takeIf { it.isNotBlank() }?.let { userAgent ->
+                args += "--user-agent=$userAgent"
+            }
+
+            val builder = CefAppBuilder()
+            builder.setInstallDir(File(System.getProperty("user.home"), ".compose-webview/jcef"))
+            builder.getCefSettings().windowless_rendering_enabled = false
+            builder.getCefSettings().root_cache_path =
+                File(System.getProperty("user.home"), ".compose-webview/jcef/cache").absolutePath
+            if (args.isNotEmpty()) {
+                builder.addJcefArgs(*args.toTypedArray())
+            }
+            app = builder.build()
+        }
+    }
+
+    fun createClient(): CefClient? = app?.createClient()
+}

--- a/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/DownloadUtils.desktop.kt
+++ b/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/DownloadUtils.desktop.kt
@@ -10,7 +10,7 @@ actual object DownloadUtils {
         description: String?,
         title: String?,
     ) {
-        // Desktop can use java.awt.Desktop or KCEF download handler.
+        // Desktop can use java.awt.Desktop or a JCEF download handler.
         // For now, stub or print.
         println("Download requested: $url (Not implemented for Desktop)")
     }

--- a/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/PlatformCookieManager.desktop.kt
+++ b/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/PlatformCookieManager.desktop.kt
@@ -1,13 +1,12 @@
 package com.parkwoocheol.composewebview
 
 /**
- * Desktop implementation of [PlatformCookieManager] using KCEF.
+ * Desktop implementation of [PlatformCookieManager] using JCEF.
  */
 actual object PlatformCookieManager {
     actual suspend fun getCookies(url: String): List<PlatformCookie> {
-        // KCEF's Cookie Manager is async and callback based.
-        // Implementing full KCEF cookie support requires careful setup.
-        // Placeholder for now as KCEF implementation requires a running CefClient/Manager.
+        // JCEF's Cookie Manager is async and callback based.
+        // Full cookie support requires dedicated CefCookieManager lifecycle handling.
         return emptyList()
     }
 

--- a/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/WebViewPlatform.desktop.kt
+++ b/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/WebViewPlatform.desktop.kt
@@ -1,6 +1,5 @@
 package com.parkwoocheol.composewebview
 
-import dev.datlag.kcef.KCEFBrowser
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -9,10 +8,14 @@ import org.cef.browser.CefFrame
 import org.cef.callback.CefQueryCallback
 import org.cef.handler.CefMessageRouterHandlerAdapter
 import java.awt.BorderLayout
-import java.awt.image.BufferedImage
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import javax.swing.JPanel
 
-class DesktopWebView(val browser: KCEFBrowser) : JPanel(BorderLayout()) {
+class DesktopWebView(
+    val browser: CefBrowser,
+    val client: org.cef.CefClient,
+) : JPanel(BorderLayout()) {
     init {
         add(browser.uiComponent, BorderLayout.CENTER)
     }
@@ -120,7 +123,10 @@ actual fun WebView.platformLoadDataWithBaseURL(
     encoding: String?,
     historyUrl: String?,
 ) {
-    browser.loadHtml(data, baseUrl ?: "about:blank")
+    val charset = encoding ?: StandardCharsets.UTF_8.name()
+    val encoded = URLEncoder.encode(data, charset)
+    val type = mimeType ?: "text/html"
+    browser.loadURL("data:$type;charset=$charset,$encoded")
 }
 
 actual fun WebView.platformPostUrl(
@@ -132,7 +138,7 @@ actual fun WebView.platformEvaluateJavascript(
     script: String,
     callback: ((String) -> Unit)?,
 ) {
-    browser.executeJavaScript(script, browser.url, 0)
+    browser.executeJavaScript(script, browser.url ?: "about:blank", 0)
 }
 
 actual fun WebView.platformZoomBy(zoomFactor: Float) {
@@ -229,7 +235,7 @@ actual fun WebView.platformAddJavascriptInterface(
             true,
         )
 
-        this.browser.client.addMessageRouter(router)
+        this.client.addMessageRouter(router)
 
         // 2. Inject Polyfill Script
         // This script adapts window.AppBridgeNative.call(...) to window.cefQuery(...)
@@ -257,7 +263,7 @@ actual fun WebView.platformAddJavascriptInterface(
 
         // To ensure it persists across navigations, we should ideally use a CefLoadHandler
         // But for now, we rely on the fact that WebViewJsBridge might re-inject or we need to hook into load events.
-        // KCEF doesn't easily expose "inject on load" without a LoadHandler.
+        // Re-injection across navigations is handled via page-finished hooks in ComposeWebView.desktop.kt.
         // We will handle re-injection in ComposeWebView.desktop.kt via onPageFinished or similar if possible.
         // Actually, WebViewJsBridge.jsScript checks `if (window.AppBridge) return;`.
         // Our polyfill needs to be there before AppBridge uses it.

--- a/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/client/Clients.desktop.kt
+++ b/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/client/Clients.desktop.kt
@@ -69,7 +69,7 @@ actual open class ComposeWebViewClient {
         request: PlatformWebResourceRequest?,
         error: PlatformWebResourceError?,
     ) {
-        // TODO: Map KCEF errors to WebViewError
+        // TODO: Map JCEF errors to WebViewError
         onReceivedErrorCallback(view, request, error)
     }
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -183,7 +183,7 @@ data class ScrollPosition(
 
 - **Android**: Real-time updates via `setOnScrollChangeListener`
 - **iOS**: 100ms polling of `scrollView.contentOffset`
-- **Desktop**: Not supported (KCEF limitations)
+- **Desktop**: Not supported (current JCEF integration limitations)
 - **Web**: CORS-limited (same-origin iframes only)
 
 ---

--- a/docs/guides/features.md
+++ b/docs/guides/features.md
@@ -182,7 +182,7 @@ data class ScrollPosition(
 !!! warning "Platform Limitations"
     - **iOS**: Uses polling (100ms intervals) instead of real-time updates due to Kotlin/Native KVO complexity.
     - **Web**: Only works for same-origin iframes. Cross-origin iframes will always report (0, 0) due to CORS restrictions.
-    - **Desktop**: Not supported due to KCEF API limitations.
+    - **Desktop**: Not supported due to current JCEF API limitations.
 
 ---
 

--- a/docs/guides/state-management.md
+++ b/docs/guides/state-management.md
@@ -120,5 +120,5 @@ ComposeWebView(state = state)
 
 * **Android**: Scroll position updates in real-time via `setOnScrollChangeListener`
 * **iOS**: Scroll position updates every 100ms via polling of `scrollView.contentOffset`
-* **Desktop**: Not supported (KCEF API limitations)
+* **Desktop**: Not supported (current JCEF integration limitations)
 * **Web**: Only works for same-origin iframes; cross-origin iframes always report (0, 0) due to CORS

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,9 +44,28 @@ It provides a unified API to control WebViews across **Android**, **iOS**, **Des
 | :--- | :--- | :--- | :--- |
 | **Android** | `AndroidView` (WebView) | :white_check_mark: Stable | Full feature support |
 | **iOS** | `UIKitView` (WKWebView) | :white_check_mark: Stable | Full feature support (Seamless JS Bridge) |
-| **Desktop** | `SwingPanel` (CEF via KCEF) | :construction: Experimental | **WIP**: Basic browsing works. KCEF integration in progress. |
+| **Desktop** | `SwingPanel` (CEF via JCEF) | :construction: Experimental | **WIP**: Basic browsing works. JCEF integration in progress. |
 | **Web (JS)** | `Iframe` (DOM) | :construction: Experimental | **WIP**: Basic navigation and `postMessage` bridge. |
 | **Web (WASM)** | `Iframe` (DOM) | :construction: Experimental | **WIP**: Uses iframe with dynamic positioning. Same-origin policy restrictions. |
+
+## Desktop (macOS) Troubleshooting
+
+If JCEF fails with `IllegalAccessError` mentioning `sun.awt`, `sun.lwawt`, or `sun.lwawt.macosx`, add JVM module options to your Compose Desktop app:
+
+```kotlin
+compose.desktop {
+    application {
+        jvmArgs += listOf(
+            "--add-exports=java.desktop/sun.awt=ALL-UNNAMED",
+            "--add-opens=java.desktop/sun.awt=ALL-UNNAMED",
+            "--add-exports=java.desktop/sun.lwawt=ALL-UNNAMED",
+            "--add-opens=java.desktop/sun.lwawt=ALL-UNNAMED",
+            "--add-exports=java.desktop/sun.lwawt.macosx=ALL-UNNAMED",
+            "--add-opens=java.desktop/sun.lwawt.macosx=ALL-UNNAMED",
+        )
+    }
+}
+```
 
 !!! note "Project Focus: Mobile Productivity"
     This library is optimized for **Mobile (Android & iOS)** development. While Desktop and Web are supported, they are currently experimental. If you need a battle-tested solution primarily for Desktop/Web, other libraries might be a better fit.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ appcompat = "1.7.1"
 material = "1.12.0"
 kotlinxSerializationJson = "1.9.0"
 composeMultiplatform = "1.9.3"
-kcef = "2025.03.23"
+jcef = "141.0.10"
 materialIconsExtended = "1.7.7"
 spotless = "6.25.0"
 kotlinxCoroutines = "1.10.1"
@@ -41,7 +41,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinxCoroutines" }
-kcef = { group = "dev.datlag", name = "kcef", version.ref = "kcef" }
+jcef = { group = "me.friwi", name = "jcefmaven", version.ref = "jcef" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
 
@@ -74,5 +74,3 @@ compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeMu
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
-
-

--- a/sample/desktopApp/build.gradle.kts
+++ b/sample/desktopApp/build.gradle.kts
@@ -20,5 +20,14 @@ kotlin {
 compose.desktop {
     application {
         mainClass = "com.parkwoocheol.sample.composewebview.MainKt"
+        jvmArgs +=
+            listOf(
+                "--add-exports=java.desktop/sun.awt=ALL-UNNAMED",
+                "--add-opens=java.desktop/sun.awt=ALL-UNNAMED",
+                "--add-exports=java.desktop/sun.lwawt=ALL-UNNAMED",
+                "--add-opens=java.desktop/sun.lwawt=ALL-UNNAMED",
+                "--add-exports=java.desktop/sun.lwawt.macosx=ALL-UNNAMED",
+                "--add-opens=java.desktop/sun.lwawt.macosx=ALL-UNNAMED",
+            )
     }
 }

--- a/sample/shared/src/androidMain/kotlin/com/parkwoocheol/sample/composewebview/ui/PlatformFeatures.android.kt
+++ b/sample/shared/src/androidMain/kotlin/com/parkwoocheol/sample/composewebview/ui/PlatformFeatures.android.kt
@@ -1,0 +1,3 @@
+package com.parkwoocheol.sample.composewebview.ui
+
+internal actual val supportsFullscreenVideoDemo: Boolean = true

--- a/sample/shared/src/commonMain/kotlin/com/parkwoocheol/sample/composewebview/ui/MainScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/com/parkwoocheol/sample/composewebview/ui/MainScreen.kt
@@ -55,45 +55,57 @@ data class Feature(
 @Composable
 fun MainScreen() {
     val features =
-        listOf(
-            Feature(
-                "Basic Browser",
-                "Standard WebView with navigation controls",
-                Icons.Default.Public,
-                Primary,
-                Screen.BasicBrowser,
-            ),
-            Feature(
-                "Transient State",
-                "State lost on config change (lightweight)",
-                Icons.Default.Save,
-                Secondary,
-                Screen.TransientBrowser,
-            ),
-            Feature(
-                "HTML & JS Bridge",
-                "Two-way communication with JavaScript",
-                Icons.Default.Javascript,
-                Tertiary,
-                Screen.HtmlJs,
-            ),
-            Feature(
-                "Fullscreen Video",
-                "Native fullscreen video support",
-                Icons.Default.Videocam,
-                // Violet
-                Color(0xFF8B5CF6),
-                Screen.FullscreenVideo,
-            ),
-            Feature(
-                "Custom Client",
-                "Custom WebViewClient & Settings",
-                Icons.Default.Settings,
-                // Emerald
-                Color(0xFF10B981),
-                Screen.CustomClient,
-            ),
-        )
+        buildList {
+            add(
+                Feature(
+                    "Basic Browser",
+                    "Standard WebView with navigation controls",
+                    Icons.Default.Public,
+                    Primary,
+                    Screen.BasicBrowser,
+                ),
+            )
+            add(
+                Feature(
+                    "Transient State",
+                    "State lost on config change (lightweight)",
+                    Icons.Default.Save,
+                    Secondary,
+                    Screen.TransientBrowser,
+                ),
+            )
+            add(
+                Feature(
+                    "HTML & JS Bridge",
+                    "Two-way communication with JavaScript",
+                    Icons.Default.Javascript,
+                    Tertiary,
+                    Screen.HtmlJs,
+                ),
+            )
+            if (supportsFullscreenVideoDemo) {
+                add(
+                    Feature(
+                        "Fullscreen Video",
+                        "Native fullscreen video support",
+                        Icons.Default.Videocam,
+                        // Violet
+                        Color(0xFF8B5CF6),
+                        Screen.FullscreenVideo,
+                    ),
+                )
+            }
+            add(
+                Feature(
+                    "Custom Client",
+                    "Custom WebViewClient & Settings",
+                    Icons.Default.Settings,
+                    // Emerald
+                    Color(0xFF10B981),
+                    Screen.CustomClient,
+                ),
+            )
+        }
 
     AppTheme {
         var currentScreen by remember { mutableStateOf(Screen.Main) }

--- a/sample/shared/src/commonMain/kotlin/com/parkwoocheol/sample/composewebview/ui/PlatformFeatures.kt
+++ b/sample/shared/src/commonMain/kotlin/com/parkwoocheol/sample/composewebview/ui/PlatformFeatures.kt
@@ -1,0 +1,3 @@
+package com.parkwoocheol.sample.composewebview.ui
+
+internal expect val supportsFullscreenVideoDemo: Boolean

--- a/sample/shared/src/desktopMain/kotlin/com/parkwoocheol/sample/composewebview/ui/PlatformFeatures.desktop.kt
+++ b/sample/shared/src/desktopMain/kotlin/com/parkwoocheol/sample/composewebview/ui/PlatformFeatures.desktop.kt
@@ -1,0 +1,3 @@
+package com.parkwoocheol.sample.composewebview.ui
+
+internal actual val supportsFullscreenVideoDemo: Boolean = false

--- a/sample/shared/src/iosMain/kotlin/com/parkwoocheol/sample/composewebview/ui/PlatformFeatures.ios.kt
+++ b/sample/shared/src/iosMain/kotlin/com/parkwoocheol/sample/composewebview/ui/PlatformFeatures.ios.kt
@@ -1,0 +1,3 @@
+package com.parkwoocheol.sample.composewebview.ui
+
+internal actual val supportsFullscreenVideoDemo: Boolean = true

--- a/sample/shared/src/wasmJsMain/kotlin/com/parkwoocheol/sample/composewebview/ui/PlatformFeatures.wasmJs.kt
+++ b/sample/shared/src/wasmJsMain/kotlin/com/parkwoocheol/sample/composewebview/ui/PlatformFeatures.wasmJs.kt
@@ -1,0 +1,3 @@
+package com.parkwoocheol.sample.composewebview.ui
+
+internal actual val supportsFullscreenVideoDemo: Boolean = false


### PR DESCRIPTION
## Summary
This PR migrates Desktop internals from KCEF to direct JCEF (`me.friwi:jcefmaven`) and stabilizes macOS runtime behavior for the sample app.
It also updates docs and sample behavior to match actual Desktop support boundaries.

Related issue: #38

## What changed

### Desktop engine/runtime migration
- Switched Desktop dependency to `jcefmaven`
- Updated version catalog to `141.0.10`
- Refactored Desktop runtime/bootstrap and WebView integration for JCEF
- Added app-specific CEF cache path to reduce singleton/cache warnings

## Impact
- Public API remains unchanged.
- Changes are focused on Desktop internals, sample runtime flags, and documentation.
