### PR TITLE
docs: unify agent guidance and remove rules alias

### DIFF
--- a/.agent/rules/architecture.md
+++ b/.agent/rules/architecture.md
@@ -1,1 +1,0 @@
-../knowledge/architecture.md

--- a/.agent/rules/code_style.md
+++ b/.agent/rules/code_style.md
@@ -1,1 +1,0 @@
-../knowledge/code_style.md

--- a/.agent/rules/commands.md
+++ b/.agent/rules/commands.md
@@ -1,1 +1,0 @@
-../knowledge/commands.md

--- a/.agent/rules/overview.md
+++ b/.agent/rules/overview.md
@@ -1,1 +1,0 @@
-../knowledge/overview.md

--- a/.agent/rules/tech_stack.md
+++ b/.agent/rules/tech_stack.md
@@ -1,1 +1,0 @@
-../knowledge/tech_stack.md

--- a/.agent/skills/README.md
+++ b/.agent/skills/README.md
@@ -109,10 +109,9 @@ This project uses a unified `.agent/` directory structure:
 
 ```
 .agent/
-├── knowledge/    # Static documentation (existing)
-├── rules/        # Knowledge symlinks (existing)
-├── tools/        # Reserved for future use (existing)
-└── skills/       # Executable workflows (NEW)
+├── knowledge/    # Static documentation and canonical guidance
+├── tools/        # Reserved for future use
+└── skills/       # Executable workflows
 ```
 
 **Claude Code Compatibility**: `.claude/skills/` is a symlink to `.agent/skills/`
@@ -140,7 +139,6 @@ To create a new skill:
 ## Related Resources
 
 - **Knowledge Base**: `.agent/knowledge/` - Project documentation
-- **Project Rules**: `.agent/rules/` - Agent configuration
 - **MkDocs**: `docs/` - User-facing documentation
 
 ## License

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Purpose
+This file is a thin entrypoint for all agents.
+Detailed project guidance lives under `.agent/`.
+
+## Instruction Precedence
+1. System instructions
+2. Developer instructions
+3. User instructions
+4. Repository instructions (`AGENTS.md`, `.agent/*`, project docs)
+5. Agent defaults
+
+## Canonical Sources
+Use these files as the source of truth:
+- Project overview: `.agent/knowledge/overview.md`
+- Architecture: `.agent/knowledge/architecture.md`
+- Tech stack/platform constraints: `.agent/knowledge/tech_stack.md`
+- Commands/workflow: `.agent/knowledge/commands.md`
+- Code style: `.agent/knowledge/code_style.md`
+- Skills index: `.agent/skills/README.md`
+- Skill dependencies: `.agent/skills/DEPENDENCIES.md`
+
+## Skills Policy
+- Use a skill when explicitly requested or when task type clearly matches a skill description.
+- Read `SKILL.md` first, then only the minimum referenced files needed.
+- Prefer repository scripts/templates/assets referenced by the skill.
+
+## Knowledge Source
+Use `.agent/knowledge/*` as the single source of project guidance.
+
+## Agent Notes
+- Codex reads `AGENTS.md` directly.
+- `CLAUDE.md` and `GEMINI.md` should stay symlinked to `AGENTS.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
This PR consolidates agent guidance into a single source of truth.

- Added `AGENTS.md` as the root instruction entrypoint
- Added symlinks:
  - `CLAUDE.md -> AGENTS.md`
  - `GEMINI.md -> AGENTS.md`
- Removed `.agent/rules/*` alias symlinks
- Updated `.agent/skills/README.md` to reference `.agent/knowledge/*` only

## Impact
- Docs/agent-configuration only
- No runtime or API changes

## Validation
- Verified symlink targets with `readlink`
- Verified no remaining `.agent/rules` references in docs
