### PR TITLE
feat: suspend JSBridge handlers & iOS openURL fix (v1.8.0)

### DIFF
--- a/.agent/knowledge/architecture.md
+++ b/.agent/knowledge/architecture.md
@@ -90,6 +90,7 @@ Controller separation pattern for command handling:
 ### Key Features
 
 - **Type-Safe Registration**: `bridge.register<Input, Output>`
+- **Suspend Handler Support**: `register` and `registerNullable` accept both regular and `suspend` lambdas, enabling async operations (network calls, dialogs) before returning results to JS
 - **Promise-based JS API**: `window.AppBridge.call`
 - **Event Emission**: `bridge.emit`
 - **Kotlinx Serialization**: Automatic JSON conversion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- No changes yet.
+## [1.8.0] - 2026-03-05
+
+### Added
+- JSBridge `register` and `registerNullable` now accept `suspend` lambdas, enabling asynchronous handlers (e.g., showing dialogs, making network calls) that return results to JavaScript after completion. Both regular and suspend lambdas work transparently. (#47, #49)
+
+### Fixed
+- iOS: replaced deprecated `UIApplication.openURL(_:)` with `UIApplication.open(_:options:completionHandler:)`, fixing `mailto:`, `tel:`, and other external scheme links failing silently on iOS 10+. (#48)
 
 ## [1.7.1] - 2026-02-19
 
@@ -45,7 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iOS find API integration issues (`WKFindResult` property access alignment).
 - Cross-platform build issues across JS, WasmJs, Desktop, iOS, and shared API synchronization.
 
-[Unreleased]: https://github.com/parkwoocheol/compose-webview/compare/1.7.1...main
+[Unreleased]: https://github.com/parkwoocheol/compose-webview/compare/1.8.0...main
+[1.8.0]: https://github.com/parkwoocheol/compose-webview/compare/1.7.1...1.8.0
 [1.7.1]: https://github.com/parkwoocheol/compose-webview/compare/1.7.0...1.7.1
 [1.7.0]: https://github.com/parkwoocheol/compose-webview/compare/1.6.0...1.7.0
 [1.6.0]: https://github.com/parkwoocheol/compose-webview/compare/1.5.0...1.6.0

--- a/README.md
+++ b/README.md
@@ -541,6 +541,12 @@ fun WebViewWithJsBridge() {
                 UserResponse(success = true, message = "Updated ${userOrNull.name}")
             }
         }
+
+        // Suspend handlers — async operations before returning to JS
+        bridge.register<SearchQuery, SearchResult>("search") { query ->
+            val results = api.search(query.term) // suspend call
+            SearchResult(items = results)
+        }
     }
 
     ComposeWebView(
@@ -1035,22 +1041,23 @@ class WebViewJsBridge(
     private val nativeInterfaceName: String = "AppBridgeNative"
 ) {
     // Register a typed handler for calls from JavaScript.
+    // Accepts both regular and suspend lambdas.
     // Null input is only accepted when T is Unit.
     inline fun <reified T : Any, reified R : Any> register(
         method: String,
-        noinline handler: (T) -> R
+        noinline handler: suspend (T) -> R
     )
 
     // Register a no-argument handler
     inline fun <reified R : Any> register(
         method: String,
-        noinline handler: () -> R
+        noinline handler: suspend () -> R
     )
 
     // Register a handler for nullable payload input
     inline fun <reified T : Any, reified R : Any> registerNullable(
         method: String,
-        noinline handler: (T?) -> R
+        noinline handler: suspend (T?) -> R
     )
 
     // Emit an event to JavaScript

--- a/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewJsBridge.kt
+++ b/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewJsBridge.kt
@@ -23,9 +23,9 @@ class WebViewJsBridge(
 ) : NativeWebBridge {
     @PublishedApi internal val serializer: BridgeSerializer = serializer ?: defaultSerializer()
 
-    // Handler stores a function that takes a JSON string and returns a JSON string (or null)
+    // Handler stores a suspend function that takes a JSON string and returns a JSON string (or null)
     @PublishedApi
-    internal val handlers = mutableMapOf<String, (String?) -> String?>()
+    internal val handlers = mutableMapOf<String, suspend (String?) -> String?>()
 
     @PublishedApi
     internal var webView: WebView? = null
@@ -97,6 +97,8 @@ class WebViewJsBridge(
     /**
      * Registers a handler for the given method name.
      * The handler receives the data as type [T] and returns a result of type [R].
+     * Both regular and suspend lambdas are accepted, enabling asynchronous operations
+     * (e.g., showing a dialog, making a network call) before returning a result to JavaScript.
      * For null input from JavaScript, only [Unit] is accepted in this overload.
      * For nullable payloads, use [registerNullable].
      *
@@ -105,7 +107,7 @@ class WebViewJsBridge(
      */
     inline fun <reified T : Any, reified R : Any> register(
         method: String,
-        noinline handler: (T) -> R,
+        noinline handler: suspend (T) -> R,
     ) {
         handlers[method] = { jsonStr ->
             val inputType = typeOf<T>()
@@ -131,13 +133,14 @@ class WebViewJsBridge(
 
     /**
      * Registers a handler that takes no arguments.
+     * Both regular and suspend lambdas are accepted.
      *
      * @param method The name of the method to register.
      * @param handler The function to handle the method call.
      */
     inline fun <reified R : Any> register(
         method: String,
-        noinline handler: () -> R,
+        noinline handler: suspend () -> R,
     ) {
         handlers[method] = { _ ->
             val result = handler()
@@ -148,13 +151,14 @@ class WebViewJsBridge(
     /**
      * Registers a handler that accepts nullable input.
      * Use this overload when JavaScript may pass `null` for payloads.
+     * Both regular and suspend lambdas are accepted.
      *
      * @param method The name of the method to register.
      * @param handler The function to handle the method call.
      */
     inline fun <reified T : Any, reified R : Any> registerNullable(
         method: String,
-        noinline handler: (T?) -> R,
+        noinline handler: suspend (T?) -> R,
     ) {
         handlers[method] = { jsonStr ->
             val inputType = typeOf<T>()

--- a/compose-webview/src/commonTest/kotlin/com/parkwoocheol/composewebview/WebViewJsBridgeTest.kt
+++ b/compose-webview/src/commonTest/kotlin/com/parkwoocheol/composewebview/WebViewJsBridgeTest.kt
@@ -1,5 +1,7 @@
 package com.parkwoocheol.composewebview
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,107 +17,226 @@ data class TestResponse(val success: Boolean)
 
 class WebViewJsBridgeTest {
     @Test
-    fun testRegisterAndCall() {
-        val bridge = WebViewJsBridge()
-        var called = false
+    fun testRegisterAndCall() =
+        runTest {
+            val bridge = WebViewJsBridge()
+            var called = false
 
-        bridge.register<TestData, TestResponse>("testMethod") { data ->
-            assertEquals(1, data.id)
-            assertEquals("Test", data.name)
-            called = true
-            TestResponse(true)
-        }
-
-        val inputJson = """{"id":1,"name":"Test"}"""
-        val handler = bridge.handlers["testMethod"]
-        assertNotNull(handler)
-
-        val resultJson = handler(inputJson)
-        assertTrue(called)
-        assertEquals("""{"success":true}""", resultJson)
-    }
-
-    @Test
-    fun testRegisterNoArg() {
-        val bridge = WebViewJsBridge()
-        var called = false
-
-        bridge.register<TestResponse>("testNoArg") {
-            called = true
-            TestResponse(true)
-        }
-
-        val handler = bridge.handlers["testNoArg"]
-        assertNotNull(handler)
-
-        val resultJson = handler(null) // No arg call passes null (or empty string depending on impl, but handler wrapper handles it)
-        assertTrue(called)
-        assertEquals("""{"success":true}""", resultJson)
-    }
-
-    @Test
-    fun testRegisterUnitInputAcceptsNull() {
-        val bridge = WebViewJsBridge()
-        var called = false
-
-        bridge.register<Unit, TestResponse>("refreshSession") {
-            called = true
-            TestResponse(true)
-        }
-
-        val handler = bridge.handlers["refreshSession"]
-        assertNotNull(handler)
-
-        val resultJson = handler(null)
-        assertTrue(called)
-        assertEquals("""{"success":true}""", resultJson)
-    }
-
-    @Test
-    fun testRegisterNonNullInputRejectsNull() {
-        val bridge = WebViewJsBridge()
-
-        bridge.register<TestData, TestResponse>("testMethod") { data ->
-            TestResponse(data.id > 0)
-        }
-
-        val handler = bridge.handlers["testMethod"]
-        assertNotNull(handler)
-
-        val exception =
-            assertFailsWith<IllegalArgumentException> {
-                handler(null)
+            bridge.register<TestData, TestResponse>("testMethod") { data ->
+                assertEquals(1, data.id)
+                assertEquals("Test", data.name)
+                called = true
+                TestResponse(true)
             }
-        assertTrue(exception.message?.contains("registerNullable") == true)
-    }
 
-    @Test
-    fun testRegisterNullableInputAcceptsNull() {
-        val bridge = WebViewJsBridge()
+            val inputJson = """{"id":1,"name":"Test"}"""
+            val handler = bridge.handlers["testMethod"]
+            assertNotNull(handler)
 
-        bridge.registerNullable<TestData, TestResponse>("updateUserMaybe") { data ->
-            TestResponse(success = data == null)
+            val resultJson = handler(inputJson)
+            assertTrue(called)
+            assertEquals("""{"success":true}""", resultJson)
         }
 
-        val handler = bridge.handlers["updateUserMaybe"]
-        assertNotNull(handler)
-
-        val resultJson = handler(null)
-        assertEquals("""{"success":true}""", resultJson)
-    }
-
     @Test
-    fun testRegisterNullableInputAcceptsValue() {
-        val bridge = WebViewJsBridge()
+    fun testRegisterNoArg() =
+        runTest {
+            val bridge = WebViewJsBridge()
+            var called = false
 
-        bridge.registerNullable<TestData, TestResponse>("updateUserMaybe") { data ->
-            TestResponse(success = data?.id == 1 && data.name == "Test")
+            bridge.register<TestResponse>("testNoArg") {
+                called = true
+                TestResponse(true)
+            }
+
+            val handler = bridge.handlers["testNoArg"]
+            assertNotNull(handler)
+
+            val resultJson = handler(null)
+            assertTrue(called)
+            assertEquals("""{"success":true}""", resultJson)
         }
 
-        val handler = bridge.handlers["updateUserMaybe"]
-        assertNotNull(handler)
+    @Test
+    fun testRegisterUnitInputAcceptsNull() =
+        runTest {
+            val bridge = WebViewJsBridge()
+            var called = false
 
-        val resultJson = handler("""{"id":1,"name":"Test"}""")
-        assertEquals("""{"success":true}""", resultJson)
-    }
+            bridge.register<Unit, TestResponse>("refreshSession") {
+                called = true
+                TestResponse(true)
+            }
+
+            val handler = bridge.handlers["refreshSession"]
+            assertNotNull(handler)
+
+            val resultJson = handler(null)
+            assertTrue(called)
+            assertEquals("""{"success":true}""", resultJson)
+        }
+
+    @Test
+    fun testRegisterNonNullInputRejectsNull() =
+        runTest {
+            val bridge = WebViewJsBridge()
+
+            bridge.register<TestData, TestResponse>("testMethod") { data ->
+                TestResponse(data.id > 0)
+            }
+
+            val handler = bridge.handlers["testMethod"]
+            assertNotNull(handler)
+
+            val exception =
+                assertFailsWith<IllegalArgumentException> {
+                    handler(null)
+                }
+            assertTrue(exception.message?.contains("registerNullable") == true)
+        }
+
+    @Test
+    fun testRegisterNullableInputAcceptsNull() =
+        runTest {
+            val bridge = WebViewJsBridge()
+
+            bridge.registerNullable<TestData, TestResponse>("updateUserMaybe") { data ->
+                TestResponse(success = data == null)
+            }
+
+            val handler = bridge.handlers["updateUserMaybe"]
+            assertNotNull(handler)
+
+            val resultJson = handler(null)
+            assertEquals("""{"success":true}""", resultJson)
+        }
+
+    @Test
+    fun testRegisterNullableInputAcceptsValue() =
+        runTest {
+            val bridge = WebViewJsBridge()
+
+            bridge.registerNullable<TestData, TestResponse>("updateUserMaybe") { data ->
+                TestResponse(success = data?.id == 1 && data.name == "Test")
+            }
+
+            val handler = bridge.handlers["updateUserMaybe"]
+            assertNotNull(handler)
+
+            val resultJson = handler("""{"id":1,"name":"Test"}""")
+            assertEquals("""{"success":true}""", resultJson)
+        }
+
+    @Test
+    fun testRegisterSuspendAndCall() =
+        runTest {
+            val bridge = WebViewJsBridge()
+            var called = false
+
+            bridge.register<TestData, TestResponse>("suspendMethod") { data ->
+                delay(100)
+                called = true
+                TestResponse(data.id > 0)
+            }
+
+            val handler = bridge.handlers["suspendMethod"]
+            assertNotNull(handler)
+
+            val resultJson = handler("""{"id":1,"name":"Test"}""")
+            assertTrue(called)
+            assertEquals("""{"success":true}""", resultJson)
+        }
+
+    @Test
+    fun testRegisterSuspendNoArg() =
+        runTest {
+            val bridge = WebViewJsBridge()
+            var called = false
+
+            bridge.register<TestResponse>("suspendNoArg") {
+                delay(100)
+                called = true
+                TestResponse(true)
+            }
+
+            val handler = bridge.handlers["suspendNoArg"]
+            assertNotNull(handler)
+
+            val resultJson = handler(null)
+            assertTrue(called)
+            assertEquals("""{"success":true}""", resultJson)
+        }
+
+    @Test
+    fun testRegisterNullableSuspendAcceptsNull() =
+        runTest {
+            val bridge = WebViewJsBridge()
+
+            bridge.registerNullable<TestData, TestResponse>("suspendNullable") { data ->
+                delay(100)
+                TestResponse(success = data == null)
+            }
+
+            val handler = bridge.handlers["suspendNullable"]
+            assertNotNull(handler)
+
+            val resultJson = handler(null)
+            assertEquals("""{"success":true}""", resultJson)
+        }
+
+    @Test
+    fun testRegisterNullableSuspendAcceptsValue() =
+        runTest {
+            val bridge = WebViewJsBridge()
+
+            bridge.registerNullable<TestData, TestResponse>("suspendNullable") { data ->
+                delay(100)
+                TestResponse(success = data?.id == 1 && data.name == "Test")
+            }
+
+            val handler = bridge.handlers["suspendNullable"]
+            assertNotNull(handler)
+
+            val resultJson = handler("""{"id":1,"name":"Test"}""")
+            assertEquals("""{"success":true}""", resultJson)
+        }
+
+    @Test
+    fun testRegisterSuspendUnitInputAcceptsNull() =
+        runTest {
+            val bridge = WebViewJsBridge()
+            var called = false
+
+            bridge.register<Unit, TestResponse>("suspendRefresh") {
+                delay(50)
+                called = true
+                TestResponse(true)
+            }
+
+            val handler = bridge.handlers["suspendRefresh"]
+            assertNotNull(handler)
+
+            val resultJson = handler(null)
+            assertTrue(called)
+            assertEquals("""{"success":true}""", resultJson)
+        }
+
+    @Test
+    fun testRegisterSuspendNonNullInputRejectsNull() =
+        runTest {
+            val bridge = WebViewJsBridge()
+
+            bridge.register<TestData, TestResponse>("suspendStrict") { data ->
+                TestResponse(data.id > 0)
+            }
+
+            val handler = bridge.handlers["suspendStrict"]
+            assertNotNull(handler)
+
+            val exception =
+                assertFailsWith<IllegalArgumentException> {
+                    handler(null)
+                }
+            assertTrue(exception.message?.contains("registerNullable") == true)
+        }
 }

--- a/compose-webview/src/iosMain/kotlin/com/parkwoocheol/composewebview/DownloadUtils.ios.kt
+++ b/compose-webview/src/iosMain/kotlin/com/parkwoocheol/composewebview/DownloadUtils.ios.kt
@@ -15,7 +15,11 @@ actual object DownloadUtils {
     ) {
         val nsUrl = NSURL.URLWithString(url) ?: return
         if (UIApplication.sharedApplication.canOpenURL(nsUrl)) {
-            UIApplication.sharedApplication.openURL(nsUrl)
+            UIApplication.sharedApplication.openURL(
+                nsUrl,
+                options = emptyMap<Any?, Any>(),
+                completionHandler = null,
+            )
         }
     }
 }

--- a/compose-webview/src/iosMain/kotlin/com/parkwoocheol/composewebview/client/ComposeWebViewClient.kt
+++ b/compose-webview/src/iosMain/kotlin/com/parkwoocheol/composewebview/client/ComposeWebViewClient.kt
@@ -155,7 +155,11 @@ internal class ComposeWebViewDelegate(
 
         if (scheme != null && !scheme.startsWith("http") && !scheme.startsWith("file")) {
             if (platform.UIKit.UIApplication.sharedApplication.canOpenURL(requestUrl)) {
-                platform.UIKit.UIApplication.sharedApplication.openURL(requestUrl)
+                platform.UIKit.UIApplication.sharedApplication.openURL(
+                    requestUrl,
+                    options = emptyMap<Any?, Any>(),
+                    completionHandler = null,
+                )
                 decisionHandler(WKNavigationActionPolicy.WKNavigationActionPolicyCancel)
                 return
             }

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -119,9 +119,9 @@ Helper class for managing the connection between Kotlin and JavaScript.
 
 | Method | Description | Platform Support |
 | :--- | :--- | :--- |
-| `register<T, R>(name: String, handler: (T) -> R)` | Registers a handler that receives type `T` from JS and returns type `R`. | All platforms |
-| `register<R>(name: String, handler: () -> R)` | Registers a handler with no input argument and returns type `R`. | All platforms |
-| `registerNullable<T, R>(name: String, handler: (T?) -> R)` | Registers a handler that accepts nullable payload input from JS and returns type `R`. | All platforms |
+| `register<T, R>(name: String, handler: suspend (T) -> R)` | Registers a handler that receives type `T` from JS and returns type `R`. Accepts both regular and `suspend` lambdas. | All platforms |
+| `register<R>(name: String, handler: suspend () -> R)` | Registers a handler with no input argument and returns type `R`. Accepts both regular and `suspend` lambdas. | All platforms |
+| `registerNullable<T, R>(name: String, handler: suspend (T?) -> R)` | Registers a handler that accepts nullable payload input from JS and returns type `R`. Accepts both regular and `suspend` lambdas. | All platforms |
 | `emit(eventName: String, data: Any)` | Emits an event to JavaScript. The data object is automatically serialized to JSON. | All platforms |
 | `unregister(name: String)` | Unregisters a previously registered native handler. | All platforms |
 
@@ -130,6 +130,8 @@ Helper class for managing the connection between Kotlin and JavaScript.
 - Other non-null input types: `null` input throws an error.
 
 Use `registerNullable<T, R>` when you want `null` payloads for non-Unit types.
+
+All handlers support `suspend` lambdas, enabling asynchronous operations (e.g., network calls, dialog interactions) before returning a result to JavaScript. Regular (non-suspend) lambdas continue to work as before.
 
 ---
 

--- a/docs/guides/js-bridge.md
+++ b/docs/guides/js-bridge.md
@@ -114,6 +114,32 @@ bridge.registerNullable<UserRequest, User>("getUserMaybe") { requestOrNull ->
 }
 ```
 
+### Suspend / Async Handlers
+
+All `register` and `registerNullable` methods accept **both regular and `suspend` lambdas**. This enables handlers that perform asynchronous operations (e.g., showing a dialog and waiting for user input, making a network call) before returning a result to JavaScript.
+
+```kotlin
+// Suspend lambda — the JS Promise resolves only after the async work completes
+bridge.register<Unit, UserChoice>("showConfirmDialog") {
+    // Show a dialog and suspend until user responds
+    val result = dialogManager.showConfirm("Are you sure?")
+    UserChoice(confirmed = result)
+}
+
+// Network call
+bridge.register<SearchQuery, SearchResult>("search") { query ->
+    val results = api.search(query.term)   // suspend call
+    SearchResult(items = results)
+}
+```
+
+JavaScript callers don't need any changes — calls already return Promises:
+
+```javascript
+const choice = await window.AppBridge.call('showConfirmDialog');
+console.log("User confirmed:", choice.confirmed);
+```
+
 ---
 
 ## Calling JavaScript from Kotlin

--- a/sample/shared/src/commonMain/kotlin/com/parkwoocheol/sample/composewebview/ui/screens/HtmlJsScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/com/parkwoocheol/sample/composewebview/ui/screens/HtmlJsScreen.kt
@@ -36,6 +36,7 @@ import com.parkwoocheol.composewebview.platformJavaScriptEnabled
 import com.parkwoocheol.composewebview.rememberSaveableWebViewStateWithData
 import com.parkwoocheol.composewebview.rememberWebViewJsBridge
 import com.parkwoocheol.sample.composewebview.ui.components.AppTopBar
+import kotlinx.coroutines.delay
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -105,6 +106,7 @@ fun HtmlJsScreen(onBack: () -> Unit) {
                 <p>This is HTML content.</p>
                 <button onclick="callNative()">Call Native (User)</button>
                 <button onclick="callNativeNoReturn()">Call Native (Log)</button>
+                <button onclick="callNativeAsync()">Call Native (Async)</button>
                 <div id="message">Waiting for events...</div>
             </div>
 
@@ -121,6 +123,17 @@ fun HtmlJsScreen(onBack: () -> Unit) {
                 
                 function callNativeNoReturn() {
                      window.AppBridge.call('log', 'Hello from Web!');
+                }
+
+                function callNativeAsync() {
+                    document.getElementById('message').innerText = 'Waiting for async result...';
+                    window.AppBridge.call('slowOperation', { name: 'Web User', age: 25 })
+                        .then(response => {
+                            document.getElementById('message').innerText = 'Async response: ' + response.message;
+                        })
+                        .catch(error => {
+                            document.getElementById('message').innerText = 'Error: ' + error;
+                        });
                 }
 
                 window.AppBridge.on('nativeEvent', (data) => {
@@ -145,6 +158,14 @@ fun HtmlJsScreen(onBack: () -> Unit) {
 
         bridge.register<String, Unit>("log") { message ->
             logs.add("JS called 'log': $message")
+        }
+
+        // Suspend handler — simulates async work before returning to JS
+        bridge.register<User, UserResponse>("slowOperation") { user ->
+            logs.add("JS called 'slowOperation': starting async work...")
+            delay(2000) // Simulate network call or dialog wait
+            logs.add("JS called 'slowOperation': async work done!")
+            UserResponse(true, "Async result for ${user.name} after 2s delay")
         }
     }
 


### PR DESCRIPTION
## Summary

  - **JSBridge suspend handler support** (#47, #49): `register` and `registerNullable` now accept `suspend` lambdas directly. Existing regular lambdas continue to work transparently via Kotlin's suspend subtyping — no breaking changes.
  - **iOS deprecated API replacement** (#48): Replaced `UIApplication.openURL(_:)` with `UIApplication.open(_:options:completionHandler:)`, fixing `mailto:`, `tel:`, and other external scheme links that were silently failing.
  - Updated documentation (README, API docs, JS Bridge guide), sample app, and CHANGELOG for 1.8.0.

  ## Changes

  | Area | Files | Description |
  |------|-------|-------------|
  | Core | `WebViewJsBridge.kt` | Handler map type changed to `suspend`, register/registerNullable params unified to `suspend` function type |
  | iOS | `ComposeWebViewClient.kt`, `DownloadUtils.ios.kt` | Deprecated `openURL` → `open(_:options:completionHandler:)` |
  | Tests | `WebViewJsBridgeTest.kt` | Wrapped 6 existing tests with `runTest` + added 6 new suspend handler tests (12 total) |
  | Docs | README, `docs/api/types.md`, `docs/guides/js-bridge.md`, `.agent/knowledge/architecture.md` | API signatures and examples updated |
  | Sample | `HtmlJsScreen.kt` | Added `slowOperation` suspend handler demo (2s delay) |

  ## Breaking Changes

  None. Existing regular lambdas are automatically compatible with Kotlin's `suspend` function type via subtyping.
  
  Closes #47, #48, #49