### PR TITLE
fix(state): stabilize WebView restoration and prevent POST replay

### DIFF
--- a/.agents/skills/documentation/scripts/validate_docs.sh
+++ b/.agents/skills/documentation/scripts/validate_docs.sh
@@ -61,11 +61,22 @@ echo ""
 # Check mkdocs.yml syntax
 echo "⚙️  Checking mkdocs.yml..."
 
-if python3 -c "import yaml; yaml.safe_load(open('mkdocs.yml'))" 2>/dev/null; then
-    echo "  ✅ Valid YAML syntax"
+if python3 -c "import yaml" 2>/dev/null; then
+    if python3 - <<'PY' 2>/dev/null
+from pathlib import Path
+
+import yaml
+
+yaml.load(Path("mkdocs.yml").read_text(encoding="utf-8"), Loader=yaml.Loader)
+PY
+    then
+        echo "  ✅ Valid YAML syntax"
+    else
+        echo "  ❌ Invalid YAML syntax in mkdocs.yml"
+        ERRORS=$((ERRORS + 1))
+    fi
 else
-    echo "  ❌ Invalid YAML syntax in mkdocs.yml"
-    ERRORS=$((ERRORS + 1))
+    echo "  ⚠️  PyYAML not installed; skipping mkdocs.yml syntax check"
 fi
 
 echo ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- State: controller-driven top-level navigation now restores the latest requested URL or HTML content consistently across re-entry, while avoiding stale replayed commands after recreation.
+- State: `postUrl()` requests are no longer automatically replayed after recreation. Android native `WebView` restore remains supported when available.
+
 ## [1.8.1] - 2026-03-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.2] - 2026-04-06
+
 ### Fixed
 - State: controller-driven top-level navigation now restores the latest requested URL or HTML content consistently across re-entry, while avoiding stale replayed commands after recreation.
 - State: `postUrl()` requests are no longer automatically replayed after recreation. Android native `WebView` restore remains supported when available.
@@ -61,7 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iOS find API integration issues (`WKFindResult` property access alignment).
 - Cross-platform build issues across JS, WasmJs, Desktop, iOS, and shared API synchronization.
 
-[Unreleased]: https://github.com/parkwoocheol/compose-webview/compare/1.8.1...main
+[Unreleased]: https://github.com/parkwoocheol/compose-webview/compare/1.8.2...main
+[1.8.2]: https://github.com/parkwoocheol/compose-webview/compare/1.8.1...1.8.2
 [1.8.1]: https://github.com/parkwoocheol/compose-webview/compare/1.8.0...1.8.1
 [1.8.0]: https://github.com/parkwoocheol/compose-webview/compare/1.7.1...1.8.0
 [1.7.1]: https://github.com/parkwoocheol/compose-webview/compare/1.7.0...1.7.1

--- a/README.md
+++ b/README.md
@@ -393,13 +393,15 @@ The library provides two ways to create and remember the `WebViewState`:
 
 ### 1. Persistent State (Recommended)
 
-Uses `rememberSaveable` to preserve the WebView state (URL, scroll position, history, etc.) across configuration changes (e.g., screen rotation).
+Uses `rememberSaveable` to preserve the latest top-level WebView request across configuration changes (e.g., screen rotation). On Android, native `WebView` state is also restored when available. Other platforms restore the latest top-level `loadUrl()` or `loadHtml()` request rather than the full browser session.
 
 ```kotlin
 val state = rememberSaveableWebViewState(url = "https://google.com")
 // or for HTML data
 val state = rememberSaveableWebViewStateWithData(data = htmlContent)
 ```
+
+`WebViewController.loadUrl()` and `loadHtml()` participate in this restoration flow. `postUrl()` still runs on Android/iOS, but it is intentionally not auto-replayed after recreation because resubmitting POST requests can cause side effects.
 
 ### 2. Transient State (Lightweight)
 

--- a/compose-webview/src/androidInstrumentedTest/kotlin/com/parkwoocheol/composewebview/ComposeWebViewTest.kt
+++ b/compose-webview/src/androidInstrumentedTest/kotlin/com/parkwoocheol/composewebview/ComposeWebViewTest.kt
@@ -179,9 +179,55 @@ class ComposeWebViewTest {
         }
     }
 
+    @Test
+    fun controllerPostUrl_doesNotReplayAfterReentryWithoutNativeRestore() {
+        var show by mutableStateOf(true)
+        var testController: WebViewController? = null
+        val createdWebViews = mutableListOf<TrackingWebView>()
+
+        composeTestRule.setContent {
+            val state = rememberWebViewState(url = "about:blank")
+            val controller = rememberWebViewController()
+            testController = controller
+            val context = LocalContext.current
+
+            if (show) {
+                ComposeWebView(
+                    state = state,
+                    controller = controller,
+                    releaseStrategy = WebViewReleaseStrategy.DestroyOnRelease,
+                    factory = { _: PlatformContext ->
+                        TrackingWebView(context).also { createdWebViews += it }
+                    },
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle {
+            testController?.postUrl("https://post.example", byteArrayOf(1, 2, 3))
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            assertEquals(listOf("https://post.example"), createdWebViews.first().postedUrls)
+        }
+
+        composeTestRule.runOnIdle { show = false }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle { show = true }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            assertTrue(createdWebViews.size == 2)
+            assertTrue(createdWebViews[1].postedUrls.isEmpty())
+        }
+    }
+
     private class TrackingWebView(context: Context) : WebView(context) {
         var destroyCalled: Boolean = false
         val loadedUrls = mutableListOf<String>()
+        val postedUrls = mutableListOf<String>()
         var savedStateCalled: Boolean = false
 
         override fun loadUrl(
@@ -189,6 +235,13 @@ class ComposeWebViewTest {
             additionalHttpHeaders: MutableMap<String, String>,
         ) {
             loadedUrls += url
+        }
+
+        override fun postUrl(
+            url: String,
+            postData: ByteArray,
+        ) {
+            postedUrls += url
         }
 
         override fun saveState(outState: Bundle): WebBackForwardList? {

--- a/compose-webview/src/androidInstrumentedTest/kotlin/com/parkwoocheol/composewebview/ComposeWebViewTest.kt
+++ b/compose-webview/src/androidInstrumentedTest/kotlin/com/parkwoocheol/composewebview/ComposeWebViewTest.kt
@@ -1,6 +1,8 @@
 package com.parkwoocheol.composewebview
 
 import android.content.Context
+import android.os.Bundle
+import android.webkit.WebBackForwardList
 import android.webkit.WebView
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.getValue
@@ -9,6 +11,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
@@ -131,8 +134,69 @@ class ComposeWebViewTest {
         }
     }
 
+    @Test
+    fun controllerLoadUrl_restoresLatestRequestedContentAfterReentry() {
+        var show by mutableStateOf(true)
+        var testController: WebViewController? = null
+        val createdWebViews = mutableListOf<TrackingWebView>()
+
+        composeTestRule.setContent {
+            val state = rememberWebViewState(url = "about:blank")
+            val controller = rememberWebViewController()
+            testController = controller
+            val context = LocalContext.current
+
+            if (show) {
+                ComposeWebView(
+                    state = state,
+                    controller = controller,
+                    releaseStrategy = WebViewReleaseStrategy.DestroyOnRelease,
+                    factory = { _: PlatformContext ->
+                        TrackingWebView(context).also { createdWebViews += it }
+                    },
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle {
+            testController?.loadUrl("https://next.example")
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            assertTrue(createdWebViews.first().loadedUrls.contains("https://next.example"))
+        }
+
+        composeTestRule.runOnIdle { show = false }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle { show = true }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            assertTrue(createdWebViews.size == 2)
+            assertEquals(listOf("https://next.example"), createdWebViews[1].loadedUrls)
+        }
+    }
+
     private class TrackingWebView(context: Context) : WebView(context) {
         var destroyCalled: Boolean = false
+        val loadedUrls = mutableListOf<String>()
+        var savedStateCalled: Boolean = false
+
+        override fun loadUrl(
+            url: String,
+            additionalHttpHeaders: MutableMap<String, String>,
+        ) {
+            loadedUrls += url
+        }
+
+        override fun saveState(outState: Bundle): WebBackForwardList? {
+            savedStateCalled = true
+            return null
+        }
+
+        override fun restoreState(inState: Bundle): WebBackForwardList? = null
 
         override fun destroy() {
             destroyCalled = true

--- a/compose-webview/src/androidMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.android.kt
+++ b/compose-webview/src/androidMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.android.kt
@@ -204,6 +204,7 @@ internal actual fun ComposeWebViewImpl(
 
                     is WebContent.Post -> {
                         wv.postUrl(content.url, content.postData)
+                        state.consumePostRequest()
                     }
 
                     is WebContent.NavigatorOnly -> {

--- a/compose-webview/src/androidMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.android.kt
+++ b/compose-webview/src/androidMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.android.kt
@@ -165,6 +165,13 @@ internal actual fun ComposeWebViewImpl(
         webView?.goBack()
     }
 
+    DisposableEffect(controller, state) {
+        controller.bindState(state)
+        onDispose {
+            controller.unbindState(state)
+        }
+    }
+
     webView?.let { wv ->
         LaunchedEffect(wv, controller) {
             withContext(Dispatchers.Main) {
@@ -173,12 +180,15 @@ internal actual fun ComposeWebViewImpl(
         }
 
         LaunchedEffect(wv, state) {
-            snapshotFlow { state.content }.collect { content ->
-                when (content) {
+            snapshotFlow { state.currentContentRequest }.collect { request ->
+                if (state.shouldSkipTopLevelLoadForCurrentRequest()) {
+                    return@collect
+                }
+
+                when (val content = request.content) {
                     is WebContent.Url -> {
-                        val url = content.url
-                        if (url.isNotEmpty() && url != wv.url) {
-                            wv.loadUrl(url, content.additionalHttpHeaders)
+                        if (content.url.isNotEmpty()) {
+                            wv.loadUrl(content.url, content.additionalHttpHeaders)
                         }
                     }
 
@@ -285,35 +295,12 @@ internal actual fun ComposeWebViewImpl(
                 }.also {
                     if (isNewWebView) {
                         // Restore state if available
-                        state.bundle?.let { bundle ->
-                            it.restoreState(bundle)
-                        } ?: run {
-                            // Initial load logic if no bundle
-                            when (val content = state.content) {
-                                is WebContent.Url -> {
-                                    if (content.url.isNotEmpty()) {
-                                        it.loadUrl(content.url, content.additionalHttpHeaders)
-                                    }
-                                }
-
-                                is WebContent.Data -> {
-                                    it.loadDataWithBaseURL(
-                                        content.baseUrl,
-                                        content.data,
-                                        content.mimeType,
-                                        content.encoding,
-                                        content.historyUrl,
-                                    )
-                                }
-
-                                is WebContent.Post -> {
-                                    it.postUrl(content.url, content.postData)
-                                }
-
-                                is WebContent.NavigatorOnly -> {
-                                    // Do nothing
-                                }
+                        val restoredState =
+                            state.bundle?.let { bundle ->
+                                it.restoreState(bundle)
                             }
+                        if (restoredState != null) {
+                            state.markTopLevelLoadHandledByRestore()
                         }
 
                         onCreated(it)
@@ -325,6 +312,11 @@ internal actual fun ComposeWebViewImpl(
             modifier = Modifier,
             update = { _ -> },
             onRelease = {
+                if (releaseStrategy == WebViewReleaseStrategy.DestroyOnRelease) {
+                    val bundle = createPlatformBundle()
+                    it.platformSaveState(bundle)
+                    state.bundle = bundle
+                }
                 onDispose(it)
                 if (releaseStrategy == WebViewReleaseStrategy.DestroyOnRelease) {
                     state.webView = null

--- a/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewController.kt
+++ b/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewController.kt
@@ -155,6 +155,10 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
      * | Desktop  | ❌ Not supported | - | No-op, logs warning |
      * | Web      | ❌ Not supported | - | No-op, logs warning |
      *
+     * This request is executed immediately, but it is not automatically replayed after recreation
+     * because repeating a POST can cause duplicate side effects. Android native WebView restore may
+     * still preserve the session when available.
+     *
      * @param url The URL to post to.
      * @param postData The data to post.
      */

--- a/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewController.kt
+++ b/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewController.kt
@@ -31,42 +31,6 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
 
         data object StopLoading : NavigationEvent
 
-        data class LoadUrl(
-            val url: String,
-            val additionalHttpHeaders: Map<String, String> = emptyMap(),
-        ) : NavigationEvent
-
-        data class LoadHtml(
-            val html: String,
-            val baseUrl: String? = null,
-            val mimeType: String? = null,
-            val encoding: String? = "utf-8",
-            val historyUrl: String? = null,
-        ) : NavigationEvent
-
-        data class PostUrl(
-            val url: String,
-            val postData: ByteArray,
-        ) : NavigationEvent {
-            override fun equals(other: Any?): Boolean {
-                if (this === other) return true
-                if (other == null || this::class != other::class) return false
-
-                other as PostUrl
-
-                if (url != other.url) return false
-                if (!postData.contentEquals(other.postData)) return false
-
-                return true
-            }
-
-            override fun hashCode(): Int {
-                var result = url.hashCode()
-                result = 31 * result + postData.contentHashCode()
-                return result
-            }
-        }
-
         data class EvaluateJavascript(
             val script: String,
             val callback: ((String) -> Unit)?,
@@ -104,6 +68,8 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
     }
 
     private val navigationEvents = ReplayOnceEventFlow<NavigationEvent>()
+    private var webViewState: WebViewState? = null
+    private var pendingTopLevelContent: WebContent? = null
 
     /**
      * Whether the WebView can navigate back.
@@ -135,9 +101,12 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
         url: String,
         additionalHttpHeaders: Map<String, String> = emptyMap(),
     ) {
-        coroutineScope.launch {
-            navigationEvents.emit(NavigationEvent.LoadUrl(url, additionalHttpHeaders))
-        }
+        updateTopLevelContent(
+            WebContent.Url(
+                url = url,
+                additionalHttpHeaders = additionalHttpHeaders,
+            ),
+        )
     }
 
     /**
@@ -164,17 +133,15 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
         encoding: String? = "utf-8",
         historyUrl: String? = null,
     ) {
-        coroutineScope.launch {
-            navigationEvents.emit(
-                NavigationEvent.LoadHtml(
-                    html,
-                    baseUrl,
-                    mimeType,
-                    encoding,
-                    historyUrl,
-                ),
-            )
-        }
+        updateTopLevelContent(
+            WebContent.Data(
+                data = html,
+                baseUrl = baseUrl,
+                encoding = encoding ?: "utf-8",
+                mimeType = mimeType,
+                historyUrl = historyUrl,
+            ),
+        )
     }
 
     /**
@@ -195,9 +162,7 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
         url: String,
         postData: ByteArray,
     ) {
-        coroutineScope.launch {
-            navigationEvents.emit(NavigationEvent.PostUrl(url, postData))
-        }
+        updateTopLevelContent(WebContent.Post(url, postData))
     }
 
     /**
@@ -536,6 +501,20 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
         coroutineScope.launch { navigationEvents.emit(NavigationEvent.SaveWebArchive(filename)) }
     }
 
+    internal fun bindState(state: WebViewState) {
+        webViewState = state
+        pendingTopLevelContent?.let { pendingContent ->
+            state.updateContentRequest(pendingContent)
+            pendingTopLevelContent = null
+        }
+    }
+
+    internal fun unbindState(state: WebViewState) {
+        if (webViewState === state) {
+            webViewState = null
+        }
+    }
+
     internal suspend fun handleNavigationEvents(webView: WebView) {
         withContext(Dispatchers.Main) {
             navigationEvents.collect { event ->
@@ -544,16 +523,6 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
                     is NavigationEvent.Forward -> webView.platformGoForward()
                     is NavigationEvent.Reload -> webView.platformReload()
                     is NavigationEvent.StopLoading -> webView.platformStopLoading()
-                    is NavigationEvent.LoadUrl -> webView.platformLoadUrl(event.url, event.additionalHttpHeaders)
-                    is NavigationEvent.LoadHtml ->
-                        webView.platformLoadDataWithBaseURL(
-                            event.baseUrl,
-                            event.html,
-                            event.mimeType,
-                            event.encoding,
-                            event.historyUrl,
-                        )
-                    is NavigationEvent.PostUrl -> webView.platformPostUrl(event.url, event.postData)
                     is NavigationEvent.EvaluateJavascript -> webView.platformEvaluateJavascript(event.script, event.callback)
                     is NavigationEvent.ZoomBy -> webView.platformZoomBy(event.zoomFactor)
                     is NavigationEvent.ZoomIn -> webView.platformZoomIn()
@@ -572,6 +541,12 @@ class WebViewController(private val coroutineScope: CoroutineScope) {
                     is NavigationEvent.SaveWebArchive -> webView.platformSaveWebArchive(event.filename)
                 }
             }
+        }
+    }
+
+    private fun updateTopLevelContent(content: WebContent) {
+        webViewState?.updateContentRequest(content) ?: run {
+            pendingTopLevelContent = content
         }
     }
 }

--- a/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewState.kt
+++ b/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewState.kt
@@ -91,6 +91,7 @@ class WebViewState(webContent: WebContent) {
     private var contentRequest by mutableStateOf(WebContentRequest(webContent, 0L))
 
     internal var restoredTopLevelLoadVersion: Long? = null
+    internal var suppressLastLoadedUrlFallback: Boolean by mutableStateOf(false)
 
     /**
      * The last URL that was loaded by the WebView.
@@ -218,6 +219,18 @@ class WebViewState(webContent: WebContent) {
             )
         bundle = null
         restoredTopLevelLoadVersion = null
+        suppressLastLoadedUrlFallback = false
+    }
+
+    internal fun consumePostRequest() {
+        if (contentRequest.content !is WebContent.Post) return
+
+        contentRequest =
+            WebContentRequest(
+                content = WebContent.NavigatorOnly,
+                version = contentRequest.version,
+            )
+        suppressLastLoadedUrlFallback = true
     }
 
     internal fun markTopLevelLoadHandledByRestore() {
@@ -367,34 +380,69 @@ val WebViewStateSaver: Saver<WebViewState, Any> =
         val lastLoadedUrlKey = "lastloaded"
         val stateBundleKey = "bundle"
         val contentKey = "content"
+        val suppressLastLoadedUrlFallbackKey = "suppresslastloadedurlfallback"
 
         mapSaver(
             save = { state ->
-                val bundle = state.bundle ?: createPlatformBundle()
-                state.webView?.platformSaveState(bundle)
-
-                mapOf(
-                    pageTitleKey to state.pageTitle,
-                    lastLoadedUrlKey to state.lastLoadedUrl,
-                    stateBundleKey to bundle,
-                    contentKey to state.content.toSaveableContent(),
+                state.toSaveableStateMap(
+                    pageTitleKey,
+                    lastLoadedUrlKey,
+                    stateBundleKey,
+                    contentKey,
+                    suppressLastLoadedUrlFallbackKey,
                 )
             },
             restore = { map ->
-                val restoredContent = map[contentKey].toRestoredWebContent() ?: WebContent.NavigatorOnly
-                val webViewState = WebViewState(restoredContent)
-                webViewState.pageTitle = map[pageTitleKey] as String?
-                webViewState.lastLoadedUrl = map[lastLoadedUrlKey] as String?
-                webViewState.bundle = map[stateBundleKey] as PlatformBundle?
-                if (webViewState.bundle != null) {
-                    webViewState.markTopLevelLoadHandledByRestore()
-                }
-                webViewState
+                map.toRestoredWebViewState(
+                    pageTitleKey,
+                    lastLoadedUrlKey,
+                    stateBundleKey,
+                    contentKey,
+                    suppressLastLoadedUrlFallbackKey,
+                )
             },
         )
     }
 
-private fun WebContent.toSaveableContent(): Map<String, Any?> =
+internal fun WebViewState.toSaveableStateMap(
+    pageTitleKey: String = "pagetitle",
+    lastLoadedUrlKey: String = "lastloaded",
+    stateBundleKey: String = "bundle",
+    contentKey: String = "content",
+    suppressLastLoadedUrlFallbackKey: String = "suppresslastloadedurlfallback",
+): Map<String, Any?> {
+    val bundle = bundle ?: createPlatformBundle()
+    webView?.platformSaveState(bundle)
+
+    return mapOf(
+        pageTitleKey to pageTitle,
+        lastLoadedUrlKey to lastLoadedUrl,
+        stateBundleKey to bundle,
+        contentKey to content.toSaveableContent(),
+        suppressLastLoadedUrlFallbackKey to (suppressLastLoadedUrlFallback || content is WebContent.Post),
+    )
+}
+
+internal fun Map<String, Any?>.toRestoredWebViewState(
+    pageTitleKey: String = "pagetitle",
+    lastLoadedUrlKey: String = "lastloaded",
+    stateBundleKey: String = "bundle",
+    contentKey: String = "content",
+    suppressLastLoadedUrlFallbackKey: String = "suppresslastloadedurlfallback",
+): WebViewState {
+    val restoredContent = this[contentKey].toRestoredWebContent() ?: WebContent.NavigatorOnly
+    return WebViewState(restoredContent).also { webViewState ->
+        webViewState.pageTitle = this[pageTitleKey] as String?
+        webViewState.lastLoadedUrl = this[lastLoadedUrlKey] as String?
+        webViewState.bundle = this[stateBundleKey] as PlatformBundle?
+        webViewState.suppressLastLoadedUrlFallback = this[suppressLastLoadedUrlFallbackKey] as? Boolean ?: false
+        if (webViewState.suppressLastLoadedUrlFallback) {
+            webViewState.loadingState = LoadingState.Finished
+        }
+    }
+}
+
+internal fun WebContent.toSaveableContent(): Map<String, Any?> =
     when (this) {
         is WebContent.Url ->
             mapOf(
@@ -412,17 +460,13 @@ private fun WebContent.toSaveableContent(): Map<String, Any?> =
                 "historyUrl" to historyUrl,
             )
         is WebContent.Post ->
-            mapOf(
-                "type" to "post",
-                "url" to url,
-                "postData" to postData,
-            )
+            mapOf("type" to "navigator")
         WebContent.NavigatorOnly ->
             mapOf("type" to "navigator")
     }
 
 @Suppress("UNCHECKED_CAST")
-private fun Any?.toRestoredWebContent(): WebContent? {
+internal fun Any?.toRestoredWebContent(): WebContent? {
     val contentMap = this as? Map<String, Any?> ?: return null
     return when (contentMap["type"] as? String) {
         "url" ->
@@ -437,11 +481,6 @@ private fun Any?.toRestoredWebContent(): WebContent? {
                 encoding = contentMap["encoding"] as? String ?: "utf-8",
                 mimeType = contentMap["mimeType"] as? String?,
                 historyUrl = contentMap["historyUrl"] as? String?,
-            )
-        "post" ->
-            WebContent.Post(
-                url = contentMap["url"] as? String ?: "",
-                postData = (contentMap["postData"] as? ByteArray) ?: ByteArray(0),
             )
         "navigator" -> WebContent.NavigatorOnly
         else -> null

--- a/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewState.kt
+++ b/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewState.kt
@@ -73,6 +73,11 @@ data class ScrollPosition(
     val y: Int = 0,
 )
 
+internal data class WebContentRequest(
+    val content: WebContent,
+    val version: Long,
+)
+
 /**
  * State holder for the [ComposeWebView].
  *
@@ -83,6 +88,10 @@ data class ScrollPosition(
  */
 @Stable
 class WebViewState(webContent: WebContent) {
+    private var contentRequest by mutableStateOf(WebContentRequest(webContent, 0L))
+
+    internal var restoredTopLevelLoadVersion: Long? = null
+
     /**
      * The last URL that was loaded by the WebView.
      */
@@ -92,7 +101,14 @@ class WebViewState(webContent: WebContent) {
     /**
      * The content currently being displayed or to be displayed.
      */
-    var content: WebContent by mutableStateOf(webContent)
+    var content: WebContent
+        get() = contentRequest.content
+        set(value) {
+            updateContentRequest(value)
+        }
+
+    internal val currentContentRequest: WebContentRequest
+        get() = contentRequest
 
     /**
      * The current loading state of the WebView.
@@ -193,6 +209,23 @@ class WebViewState(webContent: WebContent) {
     var bundle: PlatformBundle? = null
 
         internal set
+
+    internal fun updateContentRequest(content: WebContent) {
+        contentRequest =
+            WebContentRequest(
+                content = content,
+                version = contentRequest.version + 1,
+            )
+        bundle = null
+        restoredTopLevelLoadVersion = null
+    }
+
+    internal fun markTopLevelLoadHandledByRestore() {
+        restoredTopLevelLoadVersion = contentRequest.version
+    }
+
+    internal fun shouldSkipTopLevelLoadForCurrentRequest(): Boolean =
+        bundle != null && restoredTopLevelLoadVersion == contentRequest.version
 }
 
 /**
@@ -337,7 +370,7 @@ val WebViewStateSaver: Saver<WebViewState, Any> =
 
         mapSaver(
             save = { state ->
-                val bundle = createPlatformBundle()
+                val bundle = state.bundle ?: createPlatformBundle()
                 state.webView?.platformSaveState(bundle)
 
                 mapOf(
@@ -353,6 +386,9 @@ val WebViewStateSaver: Saver<WebViewState, Any> =
                 webViewState.pageTitle = map[pageTitleKey] as String?
                 webViewState.lastLoadedUrl = map[lastLoadedUrlKey] as String?
                 webViewState.bundle = map[stateBundleKey] as PlatformBundle?
+                if (webViewState.bundle != null) {
+                    webViewState.markTopLevelLoadHandledByRestore()
+                }
                 webViewState
             },
         )

--- a/compose-webview/src/commonTest/kotlin/com/parkwoocheol/composewebview/WebViewControllerTest.kt
+++ b/compose-webview/src/commonTest/kotlin/com/parkwoocheol/composewebview/WebViewControllerTest.kt
@@ -1,0 +1,66 @@
+package com.parkwoocheol.composewebview
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WebViewControllerTest {
+    @Test
+    fun loadUrl_updatesBoundStateAndInvalidatesSavedBundle() =
+        runTest {
+            val controller = WebViewController(this)
+            val state = WebViewState(WebContent.Url("https://initial.example"))
+            val initialVersion = state.currentContentRequest.version
+
+            state.bundle = createPlatformBundle()
+            state.markTopLevelLoadHandledByRestore()
+
+            controller.bindState(state)
+            controller.loadUrl(
+                url = "https://next.example",
+                additionalHttpHeaders = mapOf("X-Test" to "true"),
+            )
+
+            val content = state.content as WebContent.Url
+            assertEquals("https://next.example", content.url)
+            assertEquals(mapOf("X-Test" to "true"), content.additionalHttpHeaders)
+            assertEquals(initialVersion + 1, state.currentContentRequest.version)
+            assertNull(state.bundle)
+            assertFalse(state.shouldSkipTopLevelLoadForCurrentRequest())
+        }
+
+    @Test
+    fun pendingTopLevelRequest_appliesWhenStateBinds() =
+        runTest {
+            val controller = WebViewController(this)
+            val state = WebViewState(WebContent.Url("https://initial.example"))
+            val initialVersion = state.currentContentRequest.version
+
+            controller.loadHtml("<html><body>queued</body></html>")
+            controller.bindState(state)
+
+            val content = state.content as WebContent.Data
+            assertEquals("<html><body>queued</body></html>", content.data)
+            assertEquals(initialVersion + 1, state.currentContentRequest.version)
+        }
+
+    @Test
+    fun sameUrlRequest_stillAdvancesRequestVersion() =
+        runTest {
+            val controller = WebViewController(this)
+            val state = WebViewState(WebContent.Url("https://same.example"))
+
+            controller.bindState(state)
+            controller.loadUrl("https://same.example")
+            val firstVersion = state.currentContentRequest.version
+
+            controller.loadUrl("https://same.example")
+
+            assertEquals(firstVersion + 1, state.currentContentRequest.version)
+            assertTrue(state.content is WebContent.Url)
+            assertEquals("https://same.example", (state.content as WebContent.Url).url)
+        }
+}

--- a/compose-webview/src/commonTest/kotlin/com/parkwoocheol/composewebview/WebViewStateTest.kt
+++ b/compose-webview/src/commonTest/kotlin/com/parkwoocheol/composewebview/WebViewStateTest.kt
@@ -2,6 +2,7 @@ package com.parkwoocheol.composewebview
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class WebViewStateTest {
@@ -24,6 +25,29 @@ class WebViewStateTest {
 
         state.loadingState = LoadingState.Finished
         assertEquals(LoadingState.Finished, state.loadingState)
+    }
+
+    @Test
+    fun postRequestsAreConsumedIntoNavigatorOnly() {
+        val state = WebViewState(WebContent.Post("https://example.com/post", byteArrayOf(1, 2, 3)))
+
+        state.consumePostRequest()
+
+        assertEquals(WebContent.NavigatorOnly, state.content)
+        assertTrue(state.suppressLastLoadedUrlFallback)
+    }
+
+    @Test
+    fun savedPostRequestsRestoreWithoutReplayablePostContent() {
+        val state = WebViewState(WebContent.Post("https://example.com/post", byteArrayOf(1, 2, 3)))
+        state.lastLoadedUrl = "https://example.com/post"
+
+        val restored = state.toSaveableStateMap().toRestoredWebViewState()
+
+        assertEquals(WebContent.NavigatorOnly, restored.content)
+        assertTrue(restored.suppressLastLoadedUrlFallback)
+        assertEquals(LoadingState.Finished, restored.loadingState)
+        assertFalse(restored.shouldSkipTopLevelLoadForCurrentRequest())
     }
 
     // testErrorsForUrl removed as it requires platform-specific types that are hard to instantiate in commonTest

--- a/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.desktop.kt
+++ b/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.desktop.kt
@@ -237,16 +237,23 @@ internal actual fun ComposeWebViewImpl(
         }
 
         if (webView != null) {
+            DisposableEffect(controller, state) {
+                controller.bindState(state)
+                onDispose {
+                    controller.unbindState(state)
+                }
+            }
+
             LaunchedEffect(webView, controller) {
                 controller.handleNavigationEvents(webView!!)
             }
 
             LaunchedEffect(webView) {
-                snapshotFlow { state.content }.collectLatest { content ->
+                snapshotFlow { state.currentContentRequest }.collectLatest { request ->
                     val activeWebView = webView ?: return@collectLatest
-                    when (content) {
+                    when (val content = request.content) {
                         is WebContent.Url -> {
-                            if (content.url.isNotEmpty() && state.lastLoadedUrl != content.url) {
+                            if (content.url.isNotEmpty()) {
                                 activeWebView.platformLoadUrl(content.url, content.additionalHttpHeaders)
                             }
                         }

--- a/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.desktop.kt
+++ b/compose-webview/src/desktopMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.desktop.kt
@@ -270,6 +270,7 @@ internal actual fun ComposeWebViewImpl(
 
                         is WebContent.Post -> {
                             activeWebView.platformPostUrl(content.url, content.postData)
+                            state.consumePostRequest()
                         }
 
                         is WebContent.NavigatorOnly -> Unit

--- a/compose-webview/src/iosMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.ios.kt
+++ b/compose-webview/src/iosMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.ios.kt
@@ -201,6 +201,7 @@ internal actual fun ComposeWebViewImpl(
 
                 is WebContent.Post -> {
                     webView.platformPostUrl(currentContent.url, currentContent.postData)
+                    state.consumePostRequest()
                 }
 
                 WebContent.NavigatorOnly -> Unit
@@ -208,12 +209,18 @@ internal actual fun ComposeWebViewImpl(
         }
     }
 
-    LaunchedEffect(webView, state.lastLoadedUrl, state.loadingState, state.content) {
+    LaunchedEffect(webView, state.lastLoadedUrl, state.loadingState, state.content, state.suppressLastLoadedUrlFallback) {
         if (state.content is WebContent.NavigatorOnly && state.loadingState is LoadingState.Initializing) {
-            val urlToRestore = state.lastLoadedUrl
-            if (!urlToRestore.isNullOrEmpty()) {
-                webView.runOnMainThread {
-                    webView.loadUrlWithHeaders(urlToRestore, emptyMap())
+            if (state.suppressLastLoadedUrlFallback) {
+                state.loadingState = LoadingState.Finished
+            } else {
+                val urlToRestore = state.lastLoadedUrl
+                if (!urlToRestore.isNullOrEmpty()) {
+                    webView.runOnMainThread {
+                        webView.loadUrlWithHeaders(urlToRestore, emptyMap())
+                    }
+                } else {
+                    state.loadingState = LoadingState.Finished
                 }
             }
         }

--- a/compose-webview/src/iosMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.ios.kt
+++ b/compose-webview/src/iosMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.ios.kt
@@ -122,6 +122,14 @@ internal actual fun ComposeWebViewImpl(
     val uiDelegate = remember(state) { ComposeWebViewUIDelegate(state) }
     val fullscreenObserver = remember(state) { IosFullscreenVideoObserver(state) }
     val registeredInterfaceNames = remember(webView) { mutableSetOf<String>() }
+    val currentContentRequest = state.currentContentRequest
+
+    DisposableEffect(controller, state) {
+        controller.bindState(state)
+        onDispose {
+            controller.unbindState(state)
+        }
+    }
 
     DisposableEffect(fullscreenObserver, customViewContent != null) {
         if (customViewContent != null) {
@@ -175,12 +183,11 @@ internal actual fun ComposeWebViewImpl(
         controller.handleNavigationEvents(webView)
     }
 
-    val currentContent = state.content
-    LaunchedEffect(webView, currentContent) {
+    LaunchedEffect(webView, currentContentRequest.version) {
         webView.runOnMainThread {
-            when (currentContent) {
+            when (val currentContent = currentContentRequest.content) {
                 is WebContent.Url -> {
-                    if (currentContent.url.isNotEmpty() && webView.URL?.absoluteString != currentContent.url) {
+                    if (currentContent.url.isNotEmpty()) {
                         webView.loadUrlWithHeaders(currentContent.url, currentContent.additionalHttpHeaders)
                     }
                 }

--- a/compose-webview/src/jsMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.js.kt
+++ b/compose-webview/src/jsMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.js.kt
@@ -245,6 +245,7 @@ internal actual fun ComposeWebViewImpl(
 
                 is WebContent.Post -> {
                     state.webView?.platformPostUrl(content.url, content.postData)
+                    state.consumePostRequest()
                 }
 
                 is WebContent.NavigatorOnly -> Unit

--- a/compose-webview/src/jsMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.js.kt
+++ b/compose-webview/src/jsMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.js.kt
@@ -5,10 +5,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
@@ -132,12 +130,12 @@ internal actual fun ComposeWebViewImpl(
     val density = LocalDensity.current.density
     val componentReady = remember { mutableStateOf(false) }
     val iframeElement = remember { mutableStateOf<HTMLIFrameElement?>(null) }
+    val currentContentRequest = state.currentContentRequest
 
-    LaunchedEffect(state) {
-        snapshotFlow { state.content }.collect { content ->
-            if (content is WebContent.Url) {
-                state.lastLoadedUrl = content.url
-            }
+    DisposableEffect(controller, state) {
+        controller.bindState(state)
+        onDispose {
+            controller.unbindState(state)
         }
     }
 
@@ -147,8 +145,6 @@ internal actual fun ComposeWebViewImpl(
             controller.handleNavigationEvents(webView)
         }
     }
-
-    val url = state.lastLoadedUrl ?: ""
 
     val container =
         remember {
@@ -233,10 +229,25 @@ internal actual fun ComposeWebViewImpl(
         }
     }
 
-    SideEffect {
+    LaunchedEffect(currentContentRequest.version, iframeElement.value) {
         iframeElement.value?.let { frame ->
-            if (url.isNotEmpty() && frame.src != url) {
-                frame.src = url
+            when (val content = currentContentRequest.content) {
+                is WebContent.Url -> {
+                    state.lastLoadedUrl = content.url
+                    if (content.url.isNotEmpty()) {
+                        frame.src = content.url
+                    }
+                }
+
+                is WebContent.Data -> {
+                    frame.srcdoc = content.data
+                }
+
+                is WebContent.Post -> {
+                    state.webView?.platformPostUrl(content.url, content.postData)
+                }
+
+                is WebContent.NavigatorOnly -> Unit
             }
         }
     }

--- a/compose-webview/src/wasmJsMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.wasmJs.kt
+++ b/compose-webview/src/wasmJsMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.wasmJs.kt
@@ -251,6 +251,7 @@ internal actual fun ComposeWebViewImpl(
 
                 is WebContent.Post -> {
                     state.webView?.platformPostUrl(content.url, content.postData)
+                    state.consumePostRequest()
                 }
 
                 is WebContent.NavigatorOnly -> Unit

--- a/compose-webview/src/wasmJsMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.wasmJs.kt
+++ b/compose-webview/src/wasmJsMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.wasmJs.kt
@@ -5,11 +5,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
@@ -48,7 +45,6 @@ internal actual fun ComposeWebViewImpl(
     onStartActionMode: ((WebView, PlatformActionModeCallback?) -> PlatformActionModeCallback?)?,
 ) {
     val density = LocalDensity.current.density
-    val scope = rememberCoroutineScope()
     val componentReady = remember { mutableStateOf(false) }
 
     val container =
@@ -140,15 +136,14 @@ internal actual fun ComposeWebViewImpl(
     onStartActionMode: ((WebView, PlatformActionModeCallback?) -> PlatformActionModeCallback?)?,
 ) {
     val density = LocalDensity.current.density
-    val scope = rememberCoroutineScope()
     val componentReady = remember { mutableStateOf(false) }
     val iframeElement = remember { mutableStateOf<HTMLIFrameElement?>(null) }
+    val currentContentRequest = state.currentContentRequest
 
-    LaunchedEffect(state) {
-        snapshotFlow { state.content }.collect { content ->
-            if (content is WebContent.Url) {
-                state.lastLoadedUrl = content.url
-            }
+    DisposableEffect(controller, state) {
+        controller.bindState(state)
+        onDispose {
+            controller.unbindState(state)
         }
     }
 
@@ -158,8 +153,6 @@ internal actual fun ComposeWebViewImpl(
             controller.handleNavigationEvents(webView)
         }
     }
-
-    val url = state.lastLoadedUrl ?: ""
 
     val container =
         remember {
@@ -241,12 +234,26 @@ internal actual fun ComposeWebViewImpl(
         }
     }
 
-    // Update iframe URL when state changes
-    SideEffect {
+    LaunchedEffect(currentContentRequest.version, iframeElement.value) {
         iframeElement.value?.let { frame ->
-            if (url.isNotEmpty() && frame.src != url) {
-                println("WASM WebView: Updating URL to $url")
-                frame.src = url
+            when (val content = currentContentRequest.content) {
+                is WebContent.Url -> {
+                    state.lastLoadedUrl = content.url
+                    if (content.url.isNotEmpty()) {
+                        println("WASM WebView: Updating URL to ${content.url}")
+                        frame.src = content.url
+                    }
+                }
+
+                is WebContent.Data -> {
+                    frame.srcdoc = content.data
+                }
+
+                is WebContent.Post -> {
+                    state.webView?.platformPostUrl(content.url, content.postData)
+                }
+
+                is WebContent.NavigatorOnly -> Unit
             }
         }
     }

--- a/docs/api/compose-webview.md
+++ b/docs/api/compose-webview.md
@@ -83,9 +83,10 @@ fun ComposeWebView(
 \* **Controller**: All platforms support basic navigation, but some features (like zoom) are platform-specific. See `WebViewController` documentation for details.
 
 `releaseStrategy` notes:
-- `DestroyOnRelease` (default): existing behavior, WebView is disposed when it leaves composition.
+- `DestroyOnRelease` (default): WebView is disposed when it leaves composition. Android captures native state first when possible.
 - `KeepAlive`: keeps the instance for reuse across composition exits/re-entries.
 - `KeepAlive` is currently supported on Android and iOS. Desktop/Web/WASM currently behave as `DestroyOnRelease`.
+- `loadUrl()` and `loadHtml()` are restored as the latest top-level request. `postUrl()` is not auto-replayed after recreation.
 
 ---
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -44,7 +44,7 @@ Controls the navigation and execution of the WebView.
 | :--- | :--- | :--- |
 | `loadUrl(url: String, headers: Map<String, String> = emptyMap())` | All platforms | Headers: Android/iOS only |
 | `loadHtml(html: String, baseUrl: String? = null, ...)` | All platforms | Full data loading control |
-| `postUrl(url: String, postData: ByteArray)` | Android, iOS | HTTP POST request |
+| `postUrl(url: String, postData: ByteArray)` | Android, iOS | HTTP POST request. Not auto-replayed after recreation; Android native restore may still preserve session state when available |
 | `navigateBack()` | All platforms | Check `canGoBack` first |
 | `navigateForward()` | All platforms | Check `canGoForward` first |
 | `reload()` | All platforms | Reload current page |
@@ -104,7 +104,7 @@ Controls what happens to the native WebView when the Composable leaves compositi
 
 | Value | Description | Platform Support |
 | :--- | :--- | :--- |
-| `DestroyOnRelease` | Default behavior. Release and destroy the WebView on composition exit. | All platforms |
+| `DestroyOnRelease` | Default behavior. Release and destroy the WebView on composition exit. Android captures native state first when possible. | All platforms |
 | `KeepAlive` | Keep the WebView instance for reuse after re-entry. | Android, iOS |
 
 Desktop/Web/WASM currently follow destroy-on-release behavior.

--- a/docs/guides/lifecycle.md
+++ b/docs/guides/lifecycle.md
@@ -17,7 +17,7 @@ Managing the lifecycle of a `WebView` is critical for performance and preventing
 
 ### 2. Destruction (Dispose)
 
-* **Default (`DestroyOnRelease`)**: When the `ComposeWebView` leaves the composition tree, `webView.destroy()` is called.
+* **Default (`DestroyOnRelease`)**: When the `ComposeWebView` leaves the composition tree, the current Android `WebView` state is captured first and then `webView.destroy()` is called.
 * **Optional (`KeepAlive`)**: Keep the native WebView instance alive across composition exits/re-entries (Android/iOS only).
 * **Cleanup**: Resources are still cleaned up according to your selected release strategy.
 
@@ -43,3 +43,5 @@ ComposeWebView(
 ```
 
 When using `KeepAlive`, call `destroy()` at your actual ownership boundary (for example `ViewModel.onCleared()` on Android) to avoid leaks.
+
+With `DestroyOnRelease`, Android can restore the native `WebView` session when the same `WebViewState` instance survives re-entry. Other platforms restore only the last top-level content request.

--- a/docs/guides/lifecycle.md
+++ b/docs/guides/lifecycle.md
@@ -44,4 +44,4 @@ ComposeWebView(
 
 When using `KeepAlive`, call `destroy()` at your actual ownership boundary (for example `ViewModel.onCleared()` on Android) to avoid leaks.
 
-With `DestroyOnRelease`, Android can restore the native `WebView` session when the same `WebViewState` instance survives re-entry. Other platforms restore only the last top-level content request.
+With `DestroyOnRelease`, Android can restore the native `WebView` session when the same `WebViewState` instance survives re-entry. Other platforms restore only the last top-level `loadUrl()` or `loadHtml()` request. `postUrl()` is not auto-replayed after recreation.

--- a/docs/guides/state-management.md
+++ b/docs/guides/state-management.md
@@ -12,7 +12,9 @@ Use `rememberSaveableWebViewState` when you want the WebView to **survive config
 
 ### Features
 
-* **Persistence**: Automatically saves and restores state via `SavedStateHandle`.
+* **Persistence**: Saves the latest top-level content request and restores it when the WebView is recreated.
+* **Android Native Restore**: Android also restores native `WebView` state when available, so history/session state can survive `DestroyOnRelease`.
+* **Other Platforms**: iOS/Desktop/Web restore the last top-level `loadUrl`/`loadHtml`/`postUrl` request, not the full browser session.
 * **Safety**: Handles lifecycle cleanup to prevent memory leaks.
 
 ### Usage
@@ -26,6 +28,8 @@ val state = rememberSaveableWebViewState(
 
 ComposeWebView(state = state)
 ```
+
+If you navigate with `WebViewController.loadUrl()` instead of directly changing `state.content`, the latest top-level request is still stored in `WebViewState`. This means re-entering the screen will restore the latest requested page instead of falling back to the original URL.
 
 ### Loading HTML Data
 

--- a/docs/guides/state-management.md
+++ b/docs/guides/state-management.md
@@ -14,7 +14,7 @@ Use `rememberSaveableWebViewState` when you want the WebView to **survive config
 
 * **Persistence**: Saves the latest top-level content request and restores it when the WebView is recreated.
 * **Android Native Restore**: Android also restores native `WebView` state when available, so history/session state can survive `DestroyOnRelease`.
-* **Other Platforms**: iOS/Desktop/Web restore the last top-level `loadUrl`/`loadHtml`/`postUrl` request, not the full browser session.
+* **Other Platforms**: iOS/Desktop/Web restore the last top-level `loadUrl`/`loadHtml` request, not the full browser session.
 * **Safety**: Handles lifecycle cleanup to prevent memory leaks.
 
 ### Usage
@@ -29,7 +29,9 @@ val state = rememberSaveableWebViewState(
 ComposeWebView(state = state)
 ```
 
-If you navigate with `WebViewController.loadUrl()` instead of directly changing `state.content`, the latest top-level request is still stored in `WebViewState`. This means re-entering the screen will restore the latest requested page instead of falling back to the original URL.
+If you navigate with `WebViewController.loadUrl()` or `loadHtml()` instead of directly changing `state.content`, the latest top-level request is still stored in `WebViewState`. This means re-entering the screen will restore the latest requested page instead of falling back to the original URL.
+
+`postUrl()` is intentionally treated differently. It executes normally on Android/iOS, but it is not auto-replayed after recreation because resubmitting a POST request can cause duplicate side effects. Android native `WebView` restore may still preserve the session when available.
 
 ### Loading HTML Data
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,8 +54,8 @@ markdown_extensions:
   - toc:
       permalink: true
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary

- make top-level navigation state-driven so the latest `loadUrl()` / `loadHtml()` request is restored after recreation
- prevent stale controller commands from replaying after re-entry
- stop auto-replaying `postUrl()` after recreation while keeping Android native `WebView` restore when available
- align the `1.8.2` changelog and docs with the actual restoration semantics

## Changes

- bind controller-driven top-level navigation to `WebViewState` request versions instead of replayed transient load events
- update `WebViewState` saving/restoration so new top-level requests invalidate stale bundles and POST requests are consumed into `NavigatorOnly` after execution
- keep Android restore priority as `KeepAlive WebView` -> native bundle restore -> latest top-level request replay
- prevent non-Android fallback restoration from turning a previous POST session into an implicit GET via `lastLoadedUrl`
- add regression coverage for controller-driven restoration and for `postUrl()` not replaying after recreation
- update README, API/guides, `CHANGELOG`, `mkdocs.yml`, and docs validation behavior to match the new policy

## Verification

- `./gradlew spotlessCheck lintDebug :compose-webview:assembleDebug :compose-webview:testDebugUnitTest :compose-webview:compileDebugAndroidTestKotlinAndroid :compose-webview:compileKotlinDesktop :compose-webview:compileKotlinJs :compose-webview:compileKotlinWasmJs :compose-webview:linkIosSimulatorArm64 :compose-webview:iosSimulatorArm64Test`
- `./gradlew lint`
- `./.venv-mkdocs/bin/mkdocs build --strict`
- `bash .agents/skills/documentation/scripts/validate_docs.sh`

## Issue Context

- follows up on `#54`
- fixes `#57`