### PR TITLE
feat(android): add origin-aware JS bridge for 1.9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,10 +100,19 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Run Android Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 36
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_7_pro
           script: ./gradlew :compose-webview:connectedDebugAndroidTest
 
   # Build and test iOS (macOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,27 @@ jobs:
       - name: Android Lint
         run: ./gradlew lintDebug
 
+  docs:
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs
+        run: pip install mkdocs-material
+
+      - name: Validate Docs
+        run: bash .agents/skills/documentation/scripts/validate_docs.sh
+
+      - name: Build Docs (Strict)
+        run: bash .agents/skills/documentation/scripts/mkdocs_build.sh
+
   # Build and test Android, Desktop, Web (Ubuntu)
   build-common:
     needs: quality
@@ -62,6 +83,28 @@ jobs:
 
       - name: Build WASM
         run: ./gradlew :compose-webview:compileKotlinWasmJs
+
+  android-instrumented:
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Run Android Instrumentation Tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 36
+          script: ./gradlew :compose-webview:connectedDebugAndroidTest
 
   # Build and test iOS (macOS)
   build-ios:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,8 +31,9 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material 
-      - run: mkdocs build
+      - run: pip install mkdocs-material
+      - run: bash .agents/skills/documentation/scripts/validate_docs.sh
+      - run: bash .agents/skills/documentation/scripts/mkdocs_build.sh
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,68 @@ permissions:
   contents: read
 
 jobs:
+  verify:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Check Code Style (Spotless)
+        run: ./gradlew spotlessCheck
+
+      - name: Install MkDocs
+        run: pip install mkdocs-material
+
+      - name: Validate Docs
+        run: bash .agents/skills/documentation/scripts/validate_docs.sh
+
+      - name: Build Docs (Strict)
+        run: bash .agents/skills/documentation/scripts/mkdocs_build.sh
+
+      - name: Run Multiplatform Tests
+        run: ./gradlew :compose-webview:allTests
+
+  android-instrumented:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Run Android Instrumentation Tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 36
+          script: ./gradlew :compose-webview:connectedDebugAndroidTest
+
   publish:
+    needs:
+      - verify
+      - android-instrumented
     runs-on: macos-latest
 
     steps:
@@ -40,9 +101,6 @@ jobs:
           fi
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "Publishing version: $VERSION"
-
-      - name: Check Code Style (Spotless)
-        run: ./gradlew spotlessCheck
 
       - name: Publish to Maven Central
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,10 +66,19 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Run Android Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 36
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_7_pro
           script: ./gradlew :compose-webview:connectedDebugAndroidTest
 
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-04-27
+
+### Added
+- Android: added `rememberAndroidWebViewJsBridge(...)` with origin-aware configuration and origin-aware/compatibility policy
+  selection, and bridge capability reporting.
+- JSBridge: added `BridgeInvocationContext`, `BridgeCapabilities`, and `registerWithContext(...)` for
+  invocation-aware handler registration.
+- Android: added experimental raw message APIs (`registerMessage`, `postMainFrameMessage`) and
+  `WebMessageChannel` sessions via `openMainFrameSession(...)`.
+
+### Changed
+- Android: `rememberWebViewJsBridge()` continues to use the compatibility bridge path, while the new origin-aware
+  Android bridge uses `addWebMessageListener` plus document-start bootstrap for documents matched by
+  `allowedOriginRules`.
+
 ## [1.8.2] - 2026-04-06
 
 ### Fixed
@@ -63,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iOS find API integration issues (`WKFindResult` property access alignment).
 - Cross-platform build issues across JS, WasmJs, Desktop, iOS, and shared API synchronization.
 
-[Unreleased]: https://github.com/parkwoocheol/compose-webview/compare/1.8.2...main
+[Unreleased]: https://github.com/parkwoocheol/compose-webview/compare/1.9.0...main
+[1.9.0]: https://github.com/parkwoocheol/compose-webview/compare/1.8.2...1.9.0
 [1.8.2]: https://github.com/parkwoocheol/compose-webview/compare/1.8.1...1.8.2
 [1.8.1]: https://github.com/parkwoocheol/compose-webview/compare/1.8.0...1.8.1
 [1.8.0]: https://github.com/parkwoocheol/compose-webview/compare/1.7.1...1.8.0

--- a/README.md
+++ b/README.md
@@ -200,11 +200,12 @@ We focused heavily on making the interaction between Kotlin and JavaScript as se
 
 ## 📦 Installation
 
-This library is available on **Maven Central** for universal access without authentication starting from **v1.6.0**.
+This library is available on **Maven Central** for universal access without authentication.
 
-> **Important**: Future versions (v1.6.1+) will be available **only on Maven Central**. The current version v1.6.0 is available on all repositories but uses different group IDs:
-> - JitPack/GitHub Packages: `com.github.parkwoocheol:compose-webview:1.6.0`
-> - Maven Central: `io.github.parkwoocheol:compose-webview:1.6.0` ← **Recommended**
+> **Current coordinates**: `io.github.parkwoocheol:compose-webview:<version>`
+>
+> **Migration Note**: `v1.6.0` was the transitional release that existed on both Maven Central and
+> JitPack/GitHub Packages with different group IDs. `v1.6.1` and later use Maven Central only.
 >
 > **Migration Note**: If you're upgrading from v1.5.x or earlier, see the [Migration Guide](#migration-from-jitpackgithub-packages) below.
 
@@ -296,11 +297,11 @@ If you previously used this library from JitPack or GitHub Packages, here's how 
 | Version | Repository | Group ID | Coordinates |
 |---------|------------|----------|-------------|
 | v1.5.x and earlier | JitPack, GitHub Packages | `com.github.parkwoocheol` | `com.github.parkwoocheol:compose-webview:1.5.x` |
-| **v1.6.0** (current) | JitPack, GitHub Packages | `com.github.parkwoocheol` | `com.github.parkwoocheol:compose-webview:1.6.0` |
-| **v1.6.0** (current) | **Maven Central** | `io.github.parkwoocheol` | `io.github.parkwoocheol:compose-webview:1.6.0` |
-| **v1.6.1+** (future) | **Maven Central only** | `io.github.parkwoocheol` | `io.github.parkwoocheol:compose-webview:1.6.1+` |
+| **v1.6.0** (transitional) | JitPack, GitHub Packages | `com.github.parkwoocheol` | `com.github.parkwoocheol:compose-webview:1.6.0` |
+| **v1.6.0** (transitional) | **Maven Central** | `io.github.parkwoocheol` | `io.github.parkwoocheol:compose-webview:1.6.0` |
+| **v1.6.1 and later** | **Maven Central only** | `io.github.parkwoocheol` | `io.github.parkwoocheol:compose-webview:<version>` |
 
-> **Note**: v1.6.0 uses different group IDs depending on the repository. Same version, different coordinates.
+> **Note**: `v1.6.0` uses different group IDs depending on the repository. `v1.6.1` and later use Maven Central only.
 
 #### Recommended: Three-Step Migration
 
@@ -549,6 +550,11 @@ fun WebViewWithJsBridge() {
             val results = api.search(query.term) // suspend call
             SearchResult(items = results)
         }
+
+        bridge.registerWithContext<User, UserResponse>("updateUserFromTrustedFrame") { user ->
+            println("Called from origin=$sourceOrigin mainFrame=$isMainFrame via $transport")
+            UserResponse(success = true, message = "Handled ${user.name}")
+        }
     }
 
     ComposeWebView(
@@ -604,6 +610,81 @@ async function logMessage() {
 - Other non-null input types: `null` throws an input type error.
 
 Use `registerNullable<T, R>` when a payload type may be `null` from JavaScript.
+
+`registerWithContext<T, R>` exposes `sourceOrigin`, `isMainFrame`, and `transport`. On Android these values are
+most useful with `rememberAndroidWebViewJsBridge(...)`, which uses origin-aware WebView message APIs for documents
+matched by `allowedOriginRules`.
+
+#### Android Origin-Aware Bridge
+
+For Android web content served from origins listed in `allowedOriginRules`, prefer
+`rememberAndroidWebViewJsBridge(...)` over the default bridge:
+
+```kotlin
+val bridge =
+    rememberAndroidWebViewJsBridge(
+        config =
+            AndroidWebViewJsBridgeConfig(
+                allowedOriginRules = setOf("https://example.com"),
+                policy = AndroidJsBridgePolicy.OriginAwareOnly,
+            ),
+    )
+```
+
+Notes:
+- `rememberWebViewJsBridge()` remains the default cross-platform bridge.
+- On Android, `rememberWebViewJsBridge()` is compatibility-oriented and keeps the existing `addJavascriptInterface`
+  flow.
+- `rememberAndroidWebViewJsBridge()` enables `addWebMessageListener` + document-start bootstrap with
+  `allowedOriginRules`, and can fall back to a compatibility bridge when `policy = Compatible`.
+- `policy = Compatible` is a migration/fallback mode. It intentionally restores `addJavascriptInterface`-style
+  exposure for pages that do not receive the origin-aware bridge, so it should not be treated as equivalent to
+  `OriginAwareOnly`.
+
+#### Android Experimental Message APIs
+
+The origin-aware Android bridge also exposes optional experimental APIs for raw string/binary messages and main-frame
+message-channel sessions:
+
+```kotlin
+@OptIn(ExperimentalComposeWebViewApi::class)
+LaunchedEffect(bridge) {
+    bridge.registerMessage("echoText") { message ->
+        when (message) {
+            is AndroidBridgeMessage.Text -> AndroidBridgeMessage.Text("echo:${message.value}")
+            is AndroidBridgeMessage.Binary -> AndroidBridgeMessage.Binary(message.value)
+        }
+    }
+
+    bridge.postMainFrameMessage(
+        targetOrigin = "https://example.com",
+        message = AndroidBridgeMessage.Text("native-ready"),
+    )
+
+    val session = bridge.openMainFrameSession("https://example.com")
+    session?.setMessageHandler { payload ->
+        println("Session payload: $payload")
+    }
+}
+```
+
+These experimental APIs map directly to Android `postWebMessage` and `WebMessageChannel`. Treat them as
+main-frame transport primitives, not as the same trust boundary as inbound `addWebMessageListener`.
+
+JavaScript helpers added by the origin-aware Android bridge:
+
+```javascript
+window.AppBridge.onMessage((payload) => {
+  console.log('Native message:', payload);
+});
+
+window.AppBridge.onSession((session) => {
+  session.onMessage((payload) => console.log('Session payload:', payload));
+  session.postMessage('hello from JS session');
+});
+
+const echoed = await window.AppBridge.callMessage('echoText', 'hello');
+```
 
 #### Customizing Bridge Name
 
@@ -1042,12 +1123,20 @@ class WebViewJsBridge(
     val jsObjectName: String = "AppBridge",
     private val nativeInterfaceName: String = "AppBridgeNative"
 ) {
+    val capabilities: BridgeCapabilities
+
     // Register a typed handler for calls from JavaScript.
     // Accepts both regular and suspend lambdas.
     // Null input is only accepted when T is Unit.
     inline fun <reified T : Any, reified R : Any> register(
         method: String,
         noinline handler: suspend (T) -> R
+    )
+
+    // Register a typed handler with invocation metadata.
+    inline fun <reified T : Any, reified R : Any> registerWithContext(
+        method: String,
+        noinline handler: suspend BridgeInvocationContext.(T) -> R
     )
 
     // Register a no-argument handler
@@ -1186,6 +1275,14 @@ fun rememberWebViewJsBridge(
     serializer: BridgeSerializer? = null,
     jsObjectName: String = "AppBridge",
     nativeInterfaceName: String = "AppBridgeNative"
+): WebViewJsBridge
+
+@Composable
+fun rememberAndroidWebViewJsBridge(
+    serializer: BridgeSerializer? = null,
+    jsObjectName: String = "AppBridge",
+    nativeInterfaceName: String = "AppBridgeNative",
+    config: AndroidWebViewJsBridgeConfig
 ): WebViewJsBridge
 ```
 

--- a/compose-webview/build.gradle.kts
+++ b/compose-webview/build.gradle.kts
@@ -70,6 +70,7 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.androidx.core.ktx)
             implementation(libs.androidx.appcompat)
+            implementation(libs.androidx.webkit)
             implementation(libs.material)
             implementation(libs.androidx.activity.compose)
             implementation(libs.androidx.lifecycle.runtime.compose)
@@ -130,6 +131,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+}
+
+dependencies {
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }
 
 mavenPublishing {

--- a/compose-webview/src/androidMain/kotlin/com/parkwoocheol/composewebview/AndroidOriginAwareWebViewJsBridgeRuntime.kt
+++ b/compose-webview/src/androidMain/kotlin/com/parkwoocheol/composewebview/AndroidOriginAwareWebViewJsBridgeRuntime.kt
@@ -1,0 +1,888 @@
+@file:OptIn(ExperimentalComposeWebViewApi::class)
+
+package com.parkwoocheol.composewebview
+
+import android.net.Uri
+import android.webkit.WebView
+import androidx.webkit.JavaScriptReplyProxy
+import androidx.webkit.ScriptHandler
+import androidx.webkit.WebMessageCompat
+import androidx.webkit.WebMessagePortCompat
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+internal class AndroidOriginAwareWebViewJsBridgeRuntime(
+    private val config: AndroidWebViewJsBridgeConfig,
+) : WebViewJsBridgeRuntime {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val compatibilityInterfaceName = "cwvCompat_${hashCode().toUInt().toString(16)}"
+
+    private var attachedWebView: WebView? = null
+    private var listenerInstalled: Boolean = false
+    private var documentStartHandler: ScriptHandler? = null
+    private val pendingBinaryCalls = mutableMapOf<JavaScriptReplyProxy, PendingBinaryCall>()
+    private val activeReplyChannels = linkedSetOf<AndroidBridgeReplyChannelImpl>()
+    private val activeSessions = linkedSetOf<AndroidBridgeSessionImpl>()
+    private val messageHandlers =
+        mutableMapOf<String, suspend AndroidBridgeMessageContext.(AndroidBridgeMessage) -> AndroidBridgeMessage?>()
+
+    private var currentCapabilities: BridgeCapabilities = BridgeCapabilities()
+
+    override val capabilities: BridgeCapabilities
+        get() = currentCapabilities
+
+    override fun attach(
+        bridge: WebViewJsBridge,
+        webView: WebView,
+    ) {
+        if (attachedWebView === webView) {
+            bridge.webView = webView
+            return
+        }
+
+        detachCurrent(bridge)
+
+        attachedWebView = webView
+        bridge.webView = webView
+
+        if (config.policy == AndroidJsBridgePolicy.Compatible) {
+            webView.platformAddJavascriptInterface(bridge, compatibilityInterfaceName(bridge))
+        }
+
+        val originAwareSupported = supportsOriginAwareFoundation()
+        if (!originAwareSupported) {
+            if (config.policy == AndroidJsBridgePolicy.OriginAwareOnly) {
+                error("Origin-aware Android JS bridge requires WEB_MESSAGE_LISTENER and DOCUMENT_START_SCRIPT support.")
+            }
+            installCompatibilityCapabilities()
+            return
+        }
+
+        WebViewCompat.addWebMessageListener(
+            webView,
+            bridge.nativeInterfaceName,
+            config.allowedOriginRules,
+            object : WebViewCompat.WebMessageListener {
+                override fun onPostMessage(
+                    view: WebView,
+                    message: WebMessageCompat,
+                    sourceOrigin: Uri,
+                    isMainFrame: Boolean,
+                    replyProxy: JavaScriptReplyProxy,
+                ) {
+                    handleOriginAwareMessage(
+                        bridge = bridge,
+                        message = message,
+                        sourceOrigin = normalizeOrigin(sourceOrigin),
+                        isMainFrame = isMainFrame,
+                        replyProxy = replyProxy,
+                    )
+                }
+            },
+        )
+        listenerInstalled = true
+        documentStartHandler =
+            WebViewCompat.addDocumentStartJavaScript(
+                webView,
+                buildOriginAwareBootstrapScript(bridge),
+                config.allowedOriginRules,
+            )
+        currentCapabilities =
+            BridgeCapabilities(
+                supportsOriginAwareInbound = true,
+                supportsBinaryMessages = config.enableBinaryMessages && supportsBinaryMessages(),
+                supportsPersistentReplyChannel = true,
+                supportsMainFrameOutboundMessaging = supportsMainFrameOutboundMessaging(),
+            )
+    }
+
+    override fun onPageStarted(bridge: WebViewJsBridge) {
+        invalidateTransientState()
+    }
+
+    override fun pageFinishedBootstrapScript(bridge: WebViewJsBridge): String? =
+        if (config.policy == AndroidJsBridgePolicy.Compatible) {
+            buildOriginAwareBootstrapScript(bridge) +
+                "\n" +
+                buildCompatibilityBootstrapScript(
+                    jsObjectName = bridge.jsObjectName,
+                    nativeInterfaceName = compatibilityInterfaceName(bridge),
+                )
+        } else {
+            buildOriginAwareBootstrapScript(bridge)
+        }
+
+    override fun emit(
+        bridge: WebViewJsBridge,
+        event: String,
+        payloadJson: String,
+    ) {
+        val script = "window.${bridge.jsObjectName}.trigger('$event', $payloadJson);"
+        bridge.webView?.platformEvaluateJavascript(script, null)
+    }
+
+    override fun dispose(bridge: WebViewJsBridge) {
+        detachCurrent(bridge)
+        messageHandlers.clear()
+    }
+
+    fun registerMessage(
+        method: String,
+        handler: suspend AndroidBridgeMessageContext.(AndroidBridgeMessage) -> AndroidBridgeMessage?,
+    ) {
+        messageHandlers[method] = handler
+    }
+
+    fun unregisterMessage(method: String) {
+        messageHandlers.remove(method)
+    }
+
+    fun postMainFrameMessage(
+        bridge: WebViewJsBridge,
+        targetOrigin: String,
+        message: AndroidBridgeMessage,
+    ) {
+        ensureOriginAwareOutboundAvailable()
+        val webView = attachedWebView ?: error("Bridge is not attached to an Android WebView.")
+        val targetUri = parseTargetOrigin(targetOrigin)
+        WebViewCompat.postWebMessage(webView, message.toWebMessageCompat(config.enableBinaryMessages), targetUri)
+    }
+
+    fun openSession(
+        bridge: WebViewJsBridge,
+        targetOrigin: String,
+    ): AndroidBridgeSession? {
+        ensureOriginAwareOutboundAvailable()
+        ensurePortFeatures()
+
+        val webView = attachedWebView ?: return null
+        val targetUri = parseTargetOrigin(targetOrigin)
+        val ports = WebViewCompat.createWebMessageChannel(webView)
+        val nativePort = ports[0]
+        val jsPort = ports[1]
+
+        val session =
+            AndroidBridgeSessionImpl(
+                targetOrigin = targetOrigin,
+                port = nativePort,
+                binaryEnabled = config.enableBinaryMessages && supportsBinaryMessages(),
+                onClose = { activeSessions.remove(it) },
+            )
+        activeSessions += session
+        session.installMessageCallback()
+
+        val bootstrapMessage = WebMessageCompat(SESSION_BOOTSTRAP_TOKEN, arrayOf(jsPort))
+        WebViewCompat.postWebMessage(webView, bootstrapMessage, targetUri)
+        return session
+    }
+
+    private fun detachCurrent(bridge: WebViewJsBridge) {
+        val webView = attachedWebView ?: return
+
+        invalidateTransientState()
+
+        documentStartHandler?.remove()
+        documentStartHandler = null
+
+        if (listenerInstalled && WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+            WebViewCompat.removeWebMessageListener(webView, bridge.nativeInterfaceName)
+        }
+        if (config.policy == AndroidJsBridgePolicy.Compatible) {
+            webView.removeJavascriptInterface(compatibilityInterfaceName(bridge))
+        }
+        listenerInstalled = false
+        attachedWebView = null
+        currentCapabilities = BridgeCapabilities()
+    }
+
+    private fun invalidateTransientState() {
+        activeReplyChannels.toList().forEach { it.invalidate() }
+        activeReplyChannels.clear()
+
+        activeSessions.toList().forEach { it.close() }
+        activeSessions.clear()
+
+        pendingBinaryCalls.clear()
+    }
+
+    private fun handleOriginAwareMessage(
+        bridge: WebViewJsBridge,
+        message: WebMessageCompat,
+        sourceOrigin: String?,
+        isMainFrame: Boolean,
+        replyProxy: JavaScriptReplyProxy,
+    ) {
+        if (!config.allowIframes && !isMainFrame) {
+            replyWithError(replyProxy, callbackId = null, "Bridge calls from iframes are disabled.")
+            return
+        }
+
+        val context =
+            BridgeInvocationContext(
+                sourceOrigin = sourceOrigin,
+                isMainFrame = isMainFrame,
+                transport = BridgeTransport.OriginAwareListener,
+            )
+        val replyChannel = AndroidBridgeReplyChannelImpl(replyProxy, config.enableBinaryMessages && supportsBinaryMessages())
+        activeReplyChannels += replyChannel
+
+        when (message.type) {
+            WebMessageCompat.TYPE_STRING -> handleStringMessage(bridge, message.data, context, replyChannel, replyProxy)
+            WebMessageCompat.TYPE_ARRAY_BUFFER -> handleBinaryMessage(message.arrayBuffer, replyProxy)
+        }
+    }
+
+    private fun handleStringMessage(
+        bridge: WebViewJsBridge,
+        rawMessage: String?,
+        context: BridgeInvocationContext,
+        replyChannel: AndroidBridgeReplyChannelImpl,
+        replyProxy: JavaScriptReplyProxy,
+    ) {
+        val raw = rawMessage ?: return
+        val envelope = parseEnvelope(raw) ?: return
+        val kind = envelope["kind"]?.jsonPrimitive?.contentOrNull ?: return
+
+        when (kind) {
+            KIND_TYPED_CALL -> {
+                val method = envelope["method"]?.jsonPrimitive?.contentOrNull ?: return
+                val callbackId = envelope["callbackId"]?.jsonPrimitive?.contentOrNull
+                val data = envelope["data"]?.let(::jsonElementToRawString)
+
+                bridge.scope.launch {
+                    try {
+                        val resultJson = bridge.invokeHandler(method, data, context)
+                        callbackId?.let { replyWithTypedSuccess(replyProxy, it, resultJson) }
+                    } catch (t: Throwable) {
+                        callbackId?.let { replyWithError(replyProxy, it, t.message ?: "Unknown error") }
+                    }
+                }
+            }
+
+            KIND_MESSAGE_CALL -> {
+                val method = envelope["method"]?.jsonPrimitive?.contentOrNull ?: return
+                val callbackId = envelope["callbackId"]?.jsonPrimitive?.contentOrNull ?: return
+                val value = envelope["value"]?.jsonPrimitive?.content ?: ""
+                handleExperimentalMessageCall(
+                    method = method,
+                    payload = AndroidBridgeMessage.Text(value),
+                    callbackId = callbackId,
+                    context = context,
+                    replyChannel = replyChannel,
+                    replyProxy = replyProxy,
+                )
+            }
+
+            KIND_BINARY_META -> {
+                val method = envelope["method"]?.jsonPrimitive?.contentOrNull ?: return
+                val callbackId = envelope["callbackId"]?.jsonPrimitive?.contentOrNull ?: return
+                pendingBinaryCalls[replyProxy] =
+                    PendingBinaryCall(
+                        method = method,
+                        callbackId = callbackId,
+                        context = context,
+                        replyChannel = replyChannel,
+                    )
+            }
+        }
+    }
+
+    private fun handleBinaryMessage(
+        payload: ByteArray,
+        replyProxy: JavaScriptReplyProxy,
+    ) {
+        if (!config.enableBinaryMessages || !supportsBinaryMessages()) {
+            replyWithError(replyProxy, null, "Binary bridge messaging is disabled or unsupported.")
+            return
+        }
+
+        val pending = pendingBinaryCalls.remove(replyProxy)
+        if (pending == null) {
+            replyWithError(replyProxy, null, "Received unexpected binary bridge message without metadata.")
+            return
+        }
+
+        handleExperimentalMessageCall(
+            method = pending.method,
+            payload = AndroidBridgeMessage.Binary(payload),
+            callbackId = pending.callbackId,
+            context = pending.context,
+            replyChannel = pending.replyChannel,
+            replyProxy = replyProxy,
+        )
+    }
+
+    private fun handleExperimentalMessageCall(
+        method: String,
+        payload: AndroidBridgeMessage,
+        callbackId: String,
+        context: BridgeInvocationContext,
+        replyChannel: AndroidBridgeReplyChannelImpl,
+        replyProxy: JavaScriptReplyProxy,
+    ) {
+        val handler = messageHandlers[method]
+        if (handler == null) {
+            replyWithError(replyProxy, callbackId, "No message handler found for method: $method")
+            return
+        }
+
+        val messageContext =
+            AndroidBridgeMessageContext(
+                sourceOrigin = context.sourceOrigin,
+                isMainFrame = context.isMainFrame,
+                transport = context.transport,
+                replyChannel = replyChannel,
+            )
+
+        replyChannel.scope.launch {
+            try {
+                when (val result = handler(messageContext, payload)) {
+                    null -> replyWithTextSuccess(replyProxy, callbackId, null)
+                    is AndroidBridgeMessage.Text -> replyWithTextSuccess(replyProxy, callbackId, result.value)
+                    is AndroidBridgeMessage.Binary -> replyWithBinarySuccess(replyProxy, callbackId, result.value)
+                }
+            } catch (t: Throwable) {
+                replyWithError(replyProxy, callbackId, t.message ?: "Unknown error")
+            }
+        }
+    }
+
+    private fun replyWithTypedSuccess(
+        replyProxy: JavaScriptReplyProxy,
+        callbackId: String,
+        resultJson: String?,
+    ) {
+        val envelope =
+            buildJsonObject {
+                put("__composeWebView", true)
+                put("kind", KIND_SUCCESS)
+                put("callbackId", callbackId)
+                put("result", parseJsonElement(resultJson))
+            }
+        replyProxy.postMessage(envelope.toString())
+    }
+
+    private fun replyWithTextSuccess(
+        replyProxy: JavaScriptReplyProxy,
+        callbackId: String,
+        value: String?,
+    ) {
+        val envelope =
+            buildJsonObject {
+                put("__composeWebView", true)
+                put("kind", KIND_MESSAGE_SUCCESS)
+                put("callbackId", callbackId)
+                if (value == null) {
+                    put("value", JsonNull)
+                } else {
+                    put("value", value)
+                }
+            }
+        replyProxy.postMessage(envelope.toString())
+    }
+
+    private fun replyWithBinarySuccess(
+        replyProxy: JavaScriptReplyProxy,
+        callbackId: String,
+        value: ByteArray,
+    ) {
+        ensureBinarySupportedForReplies()
+        val envelope =
+            buildJsonObject {
+                put("__composeWebView", true)
+                put("kind", KIND_MESSAGE_SUCCESS_BINARY_META)
+                put("callbackId", callbackId)
+            }
+        replyProxy.postMessage(envelope.toString())
+        replyProxy.postMessage(value)
+    }
+
+    private fun replyWithError(
+        replyProxy: JavaScriptReplyProxy,
+        callbackId: String?,
+        errorMessage: String,
+    ) {
+        val envelope =
+            buildJsonObject {
+                put("__composeWebView", true)
+                put("kind", KIND_ERROR)
+                callbackId?.let { put("callbackId", it) }
+                put("error", errorMessage)
+            }
+        replyProxy.postMessage(envelope.toString())
+    }
+
+    private fun supportsOriginAwareFoundation(): Boolean =
+        WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER) &&
+            WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)
+
+    private fun supportsBinaryMessages(): Boolean = WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_ARRAY_BUFFER)
+
+    private fun supportsMainFrameOutboundMessaging(): Boolean = WebViewFeature.isFeatureSupported(WebViewFeature.POST_WEB_MESSAGE)
+
+    private fun installCompatibilityCapabilities() {
+        currentCapabilities =
+            BridgeCapabilities(
+                supportsOriginAwareInbound = false,
+                supportsBinaryMessages = false,
+                supportsPersistentReplyChannel = false,
+                supportsMainFrameOutboundMessaging = false,
+            )
+    }
+
+    private fun ensureOriginAwareOutboundAvailable() {
+        check(listenerInstalled) {
+            "Origin-aware outbound messaging requires the origin-aware Android bridge to be attached to a document " +
+                "matched by allowedOriginRules."
+        }
+        check(WebViewFeature.isFeatureSupported(WebViewFeature.POST_WEB_MESSAGE)) {
+            "This WebView provider does not support postWebMessage."
+        }
+    }
+
+    private fun ensurePortFeatures() {
+        check(WebViewFeature.isFeatureSupported(WebViewFeature.CREATE_WEB_MESSAGE_CHANNEL)) {
+            "This WebView provider does not support WebMessageChannel."
+        }
+        check(WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_PORT_POST_MESSAGE)) {
+            "This WebView provider does not support WebMessagePort postMessage."
+        }
+        check(WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_PORT_SET_MESSAGE_CALLBACK)) {
+            "This WebView provider does not support WebMessagePort callbacks."
+        }
+        check(WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_PORT_CLOSE)) {
+            "This WebView provider does not support closing WebMessagePort instances."
+        }
+    }
+
+    private fun ensureBinarySupportedForReplies() {
+        check(config.enableBinaryMessages) {
+            "Binary bridge messaging is disabled."
+        }
+        check(supportsBinaryMessages()) {
+            "This WebView provider does not support binary WebMessage payloads."
+        }
+    }
+
+    private fun parseTargetOrigin(targetOrigin: String): Uri {
+        require(targetOrigin != "*") {
+            "Wildcard target origins are not supported by ComposeWebView's origin-aware Android bridge."
+        }
+        val uri = Uri.parse(targetOrigin)
+        require(!uri.scheme.isNullOrBlank()) {
+            "targetOrigin must be an absolute origin such as https://example.com."
+        }
+        return uri
+    }
+
+    private fun parseEnvelope(raw: String): JsonObject? = runCatching { json.parseToJsonElement(raw) as? JsonObject }.getOrNull()
+
+    private fun parseJsonElement(rawJson: String?): JsonElement =
+        if (rawJson == null) {
+            JsonNull
+        } else {
+            runCatching { json.parseToJsonElement(rawJson) }.getOrElse { JsonPrimitive(rawJson) }
+        }
+
+    private fun normalizeOrigin(origin: Uri): String? {
+        val raw = origin.toString()
+        return raw.takeUnless { it == "null" }
+    }
+
+    private fun compatibilityInterfaceName(bridge: WebViewJsBridge): String = "${bridge.nativeInterfaceName}_$compatibilityInterfaceName"
+
+    private fun jsonElementToRawString(element: JsonElement): String? =
+        when (element) {
+            JsonNull -> null
+            else -> element.toString()
+        }
+
+    private fun AndroidBridgeMessage.toWebMessageCompat(binaryEnabled: Boolean): WebMessageCompat =
+        when (this) {
+            is AndroidBridgeMessage.Text -> WebMessageCompat(value)
+            is AndroidBridgeMessage.Binary -> {
+                check(binaryEnabled && supportsBinaryMessages()) {
+                    "Binary bridge messaging is disabled or unsupported."
+                }
+                WebMessageCompat(value)
+            }
+        }
+
+    private fun buildOriginAwareBootstrapScript(bridge: WebViewJsBridge): String =
+        """
+        (() => {
+            if (window.${bridge.jsObjectName}) return;
+
+            const callbacks = {};
+            const listeners = {};
+            const rawMessageListeners = [];
+            const sessionListeners = [];
+            let pendingBinaryReplyCallbackId = null;
+            const nativeBridge = window.${bridge.nativeInterfaceName};
+            if (!nativeBridge || !nativeBridge.postMessage) return;
+            const sessionToken = ${JsonPrimitive(SESSION_BOOTSTRAP_TOKEN)};
+
+            const createCallbackId = () => 'cb_' + Math.random().toString(36).slice(2, 11);
+            const cloneList = (list) => list.slice();
+            const addListener = (bucket, callback) => {
+                bucket.push(callback);
+            };
+            const removeListener = (bucket, callback) => {
+                const index = bucket.indexOf(callback);
+                if (index >= 0) bucket.splice(index, 1);
+            };
+            const trigger = (event, data) => {
+                (listeners[event] || []).slice().forEach((callback) => callback(data));
+            };
+            const deliverRawMessage = (message) => {
+                cloneList(rawMessageListeners).forEach((callback) => callback(message));
+            };
+            const resolveCallback = (callbackId, value, isError) => {
+                const callback = callbacks[callbackId];
+                if (!callback) return;
+                if (isError) {
+                    callback.reject(value);
+                } else {
+                    callback.resolve(value);
+                }
+                delete callbacks[callbackId];
+            };
+            const createSession = (port) => {
+                const messageListeners = [];
+                port.onmessage = (event) => {
+                    const payload = event && 'data' in event ? event.data : event;
+                    cloneList(messageListeners).forEach((callback) => callback(payload));
+                };
+                return {
+                    postMessage: (message) => port.postMessage(message),
+                    onMessage: (callback) => addListener(messageListeners, callback),
+                    offMessage: (callback) => removeListener(messageListeners, callback),
+                    close: () => port.close(),
+                };
+            };
+            const handleEnvelope = (envelope) => {
+                switch (envelope.kind) {
+                    case ${JsonPrimitive(KIND_SUCCESS)}:
+                        resolveCallback(envelope.callbackId, envelope.result, false);
+                        return true;
+                    case ${JsonPrimitive(KIND_MESSAGE_SUCCESS)}:
+                        resolveCallback(envelope.callbackId, envelope.value ?? null, false);
+                        return true;
+                    case ${JsonPrimitive(KIND_MESSAGE_SUCCESS_BINARY_META)}:
+                        pendingBinaryReplyCallbackId = envelope.callbackId;
+                        return true;
+                    case ${JsonPrimitive(KIND_ERROR)}:
+                        if (envelope.callbackId) {
+                            resolveCallback(envelope.callbackId, envelope.error, true);
+                        } else {
+                            console.error(envelope.error);
+                        }
+                        return true;
+                    case ${JsonPrimitive(KIND_EVENT)}:
+                        trigger(envelope.event, envelope.data);
+                        return true;
+                    default:
+                        return false;
+                }
+            };
+            const handleInbound = (payload, ports) => {
+                if (ports && payload === sessionToken && ports[0]) {
+                    const session = createSession(ports[0]);
+                    cloneList(sessionListeners).forEach((callback) => callback(session));
+                    return;
+                }
+
+                if (payload instanceof ArrayBuffer) {
+                    if (pendingBinaryReplyCallbackId) {
+                        resolveCallback(pendingBinaryReplyCallbackId, payload, false);
+                        pendingBinaryReplyCallbackId = null;
+                    } else {
+                        deliverRawMessage(payload);
+                    }
+                    return;
+                }
+
+                if (typeof payload === 'string') {
+                    try {
+                        const envelope = JSON.parse(payload);
+                        if (envelope && envelope.__composeWebView === true && handleEnvelope(envelope)) {
+                            return;
+                        }
+                    } catch (_) {
+                    }
+                    deliverRawMessage(payload);
+                    return;
+                }
+
+                deliverRawMessage(payload);
+            };
+
+            if (nativeBridge && nativeBridge.postMessage) {
+                nativeBridge.onmessage = (event) => {
+                    const payload = event && 'data' in event ? event.data : event;
+                    handleInbound(payload, null);
+                };
+            }
+
+            window.addEventListener('message', (event) => {
+                handleInbound(event.data, event.ports || null);
+            });
+
+            window.${bridge.jsObjectName} = {
+                call: (method, data) => {
+                    return new Promise((resolve, reject) => {
+                        const callbackId = createCallbackId();
+                        callbacks[callbackId] = { resolve, reject };
+                        nativeBridge.postMessage(JSON.stringify({
+                            __composeWebView: true,
+                            kind: ${JsonPrimitive(KIND_TYPED_CALL)},
+                            method,
+                            data: data === undefined ? null : JSON.stringify(data),
+                            callbackId,
+                        }));
+                    });
+                },
+                callMessage: (method, message) => {
+                    return new Promise((resolve, reject) => {
+                        const callbackId = createCallbackId();
+                        callbacks[callbackId] = { resolve, reject };
+                        if (message instanceof ArrayBuffer) {
+                            nativeBridge.postMessage(JSON.stringify({
+                                __composeWebView: true,
+                                kind: ${JsonPrimitive(KIND_BINARY_META)},
+                                method,
+                                callbackId,
+                            }));
+                            nativeBridge.postMessage(message);
+                            return;
+                        }
+                        nativeBridge.postMessage(JSON.stringify({
+                            __composeWebView: true,
+                            kind: ${JsonPrimitive(KIND_MESSAGE_CALL)},
+                            method,
+                            value: String(message ?? ''),
+                            callbackId,
+                        }));
+                    });
+                },
+                on: (event, callback) => {
+                    if (!listeners[event]) listeners[event] = [];
+                    listeners[event].push(callback);
+                },
+                off: (event, callback) => {
+                    if (!listeners[event]) return;
+                    listeners[event] = listeners[event].filter((existing) => existing !== callback);
+                },
+                trigger,
+                onMessage: (callback) => addListener(rawMessageListeners, callback),
+                offMessage: (callback) => removeListener(rawMessageListeners, callback),
+                onSession: (callback) => addListener(sessionListeners, callback),
+                offSession: (callback) => removeListener(sessionListeners, callback),
+            };
+
+            window.dispatchEvent(new Event('AppBridgeReady'));
+        })();
+        """.trimIndent()
+
+    private fun buildCompatibilityBootstrapScript(
+        jsObjectName: String,
+        nativeInterfaceName: String,
+    ): String =
+        """
+        (() => {
+            if (window.$jsObjectName) return;
+
+            const callbacks = {};
+            const listeners = {};
+            const rawMessageListeners = [];
+            const sessionListeners = [];
+
+            const addListener = (bucket, callback) => bucket.push(callback);
+            const removeListener = (bucket, callback) => {
+                const index = bucket.indexOf(callback);
+                if (index >= 0) bucket.splice(index, 1);
+            };
+
+            window.$jsObjectName = {
+                call: (method, data) => {
+                    return new Promise((resolve, reject) => {
+                        const callbackId = 'cb_' + Math.random().toString(36).substr(2, 9);
+                        callbacks[callbackId] = { resolve, reject };
+                        const dataStr = (data === undefined || data === null) ? null : JSON.stringify(data);
+
+                        if (window.$nativeInterfaceName && window.$nativeInterfaceName.call) {
+                            window.$nativeInterfaceName.call(method, dataStr, callbackId);
+                        } else {
+                            reject("$nativeInterfaceName not found");
+                        }
+                    });
+                },
+                callMessage: () => Promise.reject('callMessage() requires the origin-aware Android bridge.'),
+                on: (event, callback) => {
+                    if (!listeners[event]) listeners[event] = [];
+                    listeners[event].push(callback);
+                },
+                off: (event, callback) => {
+                    if (!listeners[event]) return;
+                    listeners[event] = listeners[event].filter((existing) => existing !== callback);
+                },
+                trigger: (event, data) => {
+                    if (listeners[event]) {
+                        listeners[event].forEach((callback) => callback(data));
+                    }
+                },
+                onSuccess: (id, result) => {
+                    const callback = callbacks[id];
+                    if (callback) {
+                        callback.resolve(result);
+                        delete callbacks[id];
+                    }
+                },
+                onError: (id, error) => {
+                    const callback = callbacks[id];
+                    if (callback) {
+                        callback.reject(error);
+                        delete callbacks[id];
+                    }
+                },
+                onMessage: (callback) => addListener(rawMessageListeners, callback),
+                offMessage: (callback) => removeListener(rawMessageListeners, callback),
+                onSession: (callback) => addListener(sessionListeners, callback),
+                offSession: (callback) => removeListener(sessionListeners, callback),
+            };
+
+            window.dispatchEvent(new Event('AppBridgeReady'));
+        })();
+        """.trimIndent()
+
+    private data class PendingBinaryCall(
+        val method: String,
+        val callbackId: String,
+        val context: BridgeInvocationContext,
+        val replyChannel: AndroidBridgeReplyChannelImpl,
+    )
+
+    @ExperimentalComposeWebViewApi
+    private class AndroidBridgeReplyChannelImpl(
+        private val replyProxy: JavaScriptReplyProxy,
+        private val binaryEnabled: Boolean,
+    ) : AndroidBridgeReplyChannel {
+        val scope = CoroutineScope(Dispatchers.Main)
+
+        override var isActive: Boolean = true
+            private set
+
+        override suspend fun send(message: AndroidBridgeMessage) {
+            check(isActive) { "Reply channel is no longer active." }
+            when (message) {
+                is AndroidBridgeMessage.Text -> replyProxy.postMessage(message.value)
+                is AndroidBridgeMessage.Binary -> {
+                    check(binaryEnabled) { "Binary bridge messaging is disabled or unsupported." }
+                    replyProxy.postMessage(message.value)
+                }
+            }
+        }
+
+        override suspend fun sendText(value: String) {
+            send(AndroidBridgeMessage.Text(value))
+        }
+
+        override suspend fun sendBytes(value: ByteArray) {
+            send(AndroidBridgeMessage.Binary(value))
+        }
+
+        fun invalidate() {
+            isActive = false
+            scope.cancel()
+        }
+    }
+
+    @ExperimentalComposeWebViewApi
+    private class AndroidBridgeSessionImpl(
+        override val targetOrigin: String,
+        private val port: WebMessagePortCompat,
+        private val binaryEnabled: Boolean,
+        private val onClose: (AndroidBridgeSessionImpl) -> Unit,
+    ) : AndroidBridgeSession {
+        private var messageHandler: ((AndroidBridgeMessage) -> Unit)? = null
+
+        override val isMainFrame: Boolean = true
+
+        override var isActive: Boolean = true
+            private set
+
+        override fun setMessageHandler(handler: ((AndroidBridgeMessage) -> Unit)?) {
+            messageHandler = handler
+        }
+
+        override suspend fun send(message: AndroidBridgeMessage) {
+            check(isActive) { "Bridge session is no longer active." }
+            when (message) {
+                is AndroidBridgeMessage.Text -> port.postMessage(WebMessageCompat(message.value))
+                is AndroidBridgeMessage.Binary -> {
+                    check(binaryEnabled) { "Binary bridge messaging is disabled or unsupported." }
+                    port.postMessage(WebMessageCompat(message.value))
+                }
+            }
+        }
+
+        override suspend fun sendText(value: String) {
+            send(AndroidBridgeMessage.Text(value))
+        }
+
+        override suspend fun sendBytes(value: ByteArray) {
+            send(AndroidBridgeMessage.Binary(value))
+        }
+
+        override fun close() {
+            if (!isActive) return
+            isActive = false
+            port.close()
+            onClose(this)
+        }
+
+        fun installMessageCallback() {
+            port.setWebMessageCallback(
+                object : WebMessagePortCompat.WebMessageCallbackCompat() {
+                    override fun onMessage(
+                        port: WebMessagePortCompat,
+                        message: WebMessageCompat?,
+                    ) {
+                        val payload =
+                            if (message?.type == WebMessageCompat.TYPE_ARRAY_BUFFER) {
+                                AndroidBridgeMessage.Binary(message.arrayBuffer)
+                            } else {
+                                AndroidBridgeMessage.Text(message?.data.orEmpty())
+                            }
+                        messageHandler?.invoke(payload)
+                    }
+                },
+            )
+        }
+    }
+
+    private companion object {
+        private const val KIND_TYPED_CALL = "typedCall"
+        private const val KIND_MESSAGE_CALL = "messageCall"
+        private const val KIND_BINARY_META = "binaryMeta"
+        private const val KIND_SUCCESS = "success"
+        private const val KIND_MESSAGE_SUCCESS = "messageSuccess"
+        private const val KIND_MESSAGE_SUCCESS_BINARY_META = "messageSuccessBinaryMeta"
+        private const val KIND_ERROR = "error"
+        private const val KIND_EVENT = "event"
+        private const val SESSION_BOOTSTRAP_TOKEN = "__composeWebViewSession__"
+    }
+}

--- a/compose-webview/src/androidMain/kotlin/com/parkwoocheol/composewebview/AndroidWebViewJsBridge.kt
+++ b/compose-webview/src/androidMain/kotlin/com/parkwoocheol/composewebview/AndroidWebViewJsBridge.kt
@@ -1,0 +1,238 @@
+package com.parkwoocheol.composewebview
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+
+/**
+ * Policy for the Android origin-aware JS bridge.
+ */
+enum class AndroidJsBridgePolicy {
+    /**
+     * Require the origin-aware bridge path. If it cannot be installed, the bridge fails.
+     */
+    OriginAwareOnly,
+
+    /**
+     * Prefer the origin-aware bridge path, but allow a compatibility fallback for unsupported pages or providers.
+     *
+     * Compatibility fallback restores `addJavascriptInterface`-style exposure for pages that do not receive the
+     * origin-aware bridge. Use this only when your app already accepts the weaker trust model for those pages.
+     */
+    Compatible,
+}
+
+/**
+ * Configuration for the Android origin-aware JS bridge.
+ *
+ * @property allowedOriginRules Allowed origin rules forwarded to `addWebMessageListener` and
+ * `addDocumentStartJavaScript`.
+ * @property policy Controls whether the bridge must stay on the origin-aware path or may fall back to compatibility mode.
+ * @property allowIframes Whether calls from iframes are allowed on the origin-aware path.
+ * @property enableBinaryMessages Whether ArrayBuffer messaging is enabled for the experimental Android APIs.
+ */
+data class AndroidWebViewJsBridgeConfig(
+    val allowedOriginRules: Set<String>,
+    val policy: AndroidJsBridgePolicy = AndroidJsBridgePolicy.OriginAwareOnly,
+    val allowIframes: Boolean = false,
+    val enableBinaryMessages: Boolean = false,
+) {
+    init {
+        require(allowedOriginRules.isNotEmpty()) {
+            "allowedOriginRules must not be empty for rememberAndroidWebViewJsBridge()."
+        }
+    }
+}
+
+/**
+ * Remembers an origin-aware Android JS bridge backed by WebView message APIs when available.
+ *
+ * This bridge keeps the existing `window.AppBridge.call(...)` model for documents matched by
+ * [AndroidWebViewJsBridgeConfig.allowedOriginRules], while optionally falling back to a compatibility bridge for
+ * unsupported origins when [AndroidWebViewJsBridgeConfig.policy] is
+ * [AndroidJsBridgePolicy.Compatible]. The compatibility path is intended for migration and unsupported providers,
+ * not for pages that need origin-aware trust guarantees.
+ *
+ * @param serializer The serializer used for typed bridge calls.
+ * @param jsObjectName The JavaScript bridge object name. Defaults to `AppBridge`.
+ * @param nativeInterfaceName The injected native bridge object name. Defaults to `AppBridgeNative`.
+ * @param config Android-specific origin-aware bridge configuration.
+ */
+@Composable
+fun rememberAndroidWebViewJsBridge(
+    serializer: BridgeSerializer? = null,
+    jsObjectName: String = "AppBridge",
+    nativeInterfaceName: String = "AppBridgeNative",
+    config: AndroidWebViewJsBridgeConfig,
+): WebViewJsBridge {
+    val bridge =
+        remember(serializer, jsObjectName, nativeInterfaceName, config) {
+            WebViewJsBridge(
+                serializer = serializer,
+                jsObjectName = jsObjectName,
+                nativeInterfaceName = nativeInterfaceName,
+            ).also {
+                it.setRuntime(AndroidOriginAwareWebViewJsBridgeRuntime(config))
+            }
+        }
+
+    DisposableEffect(bridge) {
+        onDispose {
+            bridge.dispose()
+        }
+    }
+
+    return bridge
+}
+
+/**
+ * A string or binary message delivered by the Android origin-aware bridge APIs.
+ */
+@ExperimentalComposeWebViewApi
+sealed interface AndroidBridgeMessage {
+    /**
+     * String payload.
+     */
+    data class Text(val value: String) : AndroidBridgeMessage
+
+    /**
+     * Binary payload.
+     */
+    data class Binary(val value: ByteArray) : AndroidBridgeMessage
+}
+
+/**
+ * A frame-bound reply channel exposed by `addWebMessageListener`.
+ */
+@ExperimentalComposeWebViewApi
+interface AndroidBridgeReplyChannel {
+    /**
+     * Whether the reply channel still targets a live frame.
+     */
+    val isActive: Boolean
+
+    /**
+     * Sends a message to the frame that created this reply channel.
+     */
+    suspend fun send(message: AndroidBridgeMessage)
+
+    /**
+     * Sends a string message to the frame that created this reply channel.
+     */
+    suspend fun sendText(value: String)
+
+    /**
+     * Sends a binary message to the frame that created this reply channel.
+     */
+    suspend fun sendBytes(value: ByteArray)
+}
+
+/**
+ * Context passed to experimental Android message handlers.
+ *
+ * @property sourceOrigin The reported source origin, or `null` when unavailable.
+ * @property isMainFrame Whether the message came from the main frame.
+ * @property transport Which bridge transport delivered the message.
+ * @property replyChannel A persistent reply channel bound to the originating frame.
+ */
+@ExperimentalComposeWebViewApi
+data class AndroidBridgeMessageContext(
+    val sourceOrigin: String?,
+    val isMainFrame: Boolean,
+    val transport: BridgeTransport,
+    val replyChannel: AndroidBridgeReplyChannel?,
+)
+
+/**
+ * A native-side view of an Android WebMessageChannel session.
+ */
+@ExperimentalComposeWebViewApi
+interface AndroidBridgeSession {
+    /**
+     * The target origin used when the session was opened.
+     */
+    val targetOrigin: String
+
+    /**
+     * Always `true` for sessions opened through `postWebMessage`.
+     */
+    val isMainFrame: Boolean
+
+    /**
+     * Whether the session is still usable.
+     */
+    val isActive: Boolean
+
+    /**
+     * Registers a callback for messages posted from JavaScript on this session.
+     */
+    fun setMessageHandler(handler: ((AndroidBridgeMessage) -> Unit)?)
+
+    /**
+     * Sends a message on the session port.
+     */
+    suspend fun send(message: AndroidBridgeMessage)
+
+    /**
+     * Sends a string message on the session port.
+     */
+    suspend fun sendText(value: String)
+
+    /**
+     * Sends a binary message on the session port.
+     */
+    suspend fun sendBytes(value: ByteArray)
+
+    /**
+     * Closes the session.
+     */
+    fun close()
+}
+
+/**
+ * Registers an experimental string/binary message handler for the origin-aware Android bridge.
+ *
+ * The handler is only invoked when the bridge is created via [rememberAndroidWebViewJsBridge].
+ */
+@ExperimentalComposeWebViewApi
+fun WebViewJsBridge.registerMessage(
+    method: String,
+    handler: suspend AndroidBridgeMessageContext.(AndroidBridgeMessage) -> AndroidBridgeMessage?,
+) {
+    androidOriginAwareRuntime().registerMessage(method, handler)
+}
+
+/**
+ * Unregisters an experimental string/binary message handler from the origin-aware Android bridge.
+ */
+@ExperimentalComposeWebViewApi
+fun WebViewJsBridge.unregisterMessage(method: String) {
+    androidOriginAwareRuntime().unregisterMessage(method)
+}
+
+/**
+ * Posts a raw string or binary message to the main frame using Android's `postWebMessage`.
+ *
+ * The JavaScript page can receive this message through `window.AppBridge.onMessage(...)` or a regular `message`
+ * event listener. This API is main-frame focused and maps directly to Android's outbound WebMessage APIs.
+ */
+@ExperimentalComposeWebViewApi
+fun WebViewJsBridge.postMainFrameMessage(
+    targetOrigin: String,
+    message: AndroidBridgeMessage,
+) {
+    androidOriginAwareRuntime().postMainFrameMessage(this, targetOrigin, message)
+}
+
+/**
+ * Opens an experimental `WebMessageChannel` session with the allowed main-frame target.
+ *
+ * JavaScript can receive newly opened sessions through `window.AppBridge.onSession(...)`.
+ */
+@ExperimentalComposeWebViewApi
+fun WebViewJsBridge.openMainFrameSession(targetOrigin: String): AndroidBridgeSession? =
+    androidOriginAwareRuntime().openSession(this, targetOrigin)
+
+internal fun WebViewJsBridge.androidOriginAwareRuntime(): AndroidOriginAwareWebViewJsBridgeRuntime =
+    runtime as? AndroidOriginAwareWebViewJsBridgeRuntime
+        ?: error("Android origin-aware bridge APIs require rememberAndroidWebViewJsBridge().")

--- a/compose-webview/src/androidMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.android.kt
+++ b/compose-webview/src/androidMain/kotlin/com/parkwoocheol/composewebview/ComposeWebView.android.kt
@@ -222,8 +222,15 @@ internal actual fun ComposeWebViewImpl(
         // Inject JS Bridge script when page finishes loading
         jsBridge?.let { bridge ->
             LaunchedEffect(state.loadingState) {
-                if (state.loadingState is LoadingState.Finished) {
-                    wv.evaluateJavascript(bridge.jsScript, null)
+                when (state.loadingState) {
+                    is LoadingState.Loading -> bridge.onPageStarted()
+                    is LoadingState.Finished -> {
+                        bridge.pageFinishedBootstrapScript()?.let { script ->
+                            wv.evaluateJavascript(script, null)
+                        }
+                    }
+
+                    else -> Unit
                 }
             }
         }

--- a/compose-webview/src/androidUnitTest/kotlin/com/parkwoocheol/composewebview/AndroidWebViewJsBridgeRuntimeTest.kt
+++ b/compose-webview/src/androidUnitTest/kotlin/com/parkwoocheol/composewebview/AndroidWebViewJsBridgeRuntimeTest.kt
@@ -1,0 +1,53 @@
+package com.parkwoocheol.composewebview
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AndroidWebViewJsBridgeRuntimeTest {
+    @Test
+    fun defaultBridge_keepsExistingPageFinishedBootstrap() {
+        val bridge = WebViewJsBridge()
+
+        assertEquals(bridge.jsScript, bridge.pageFinishedBootstrapScript())
+        assertEquals(BridgeCapabilities(), bridge.capabilities)
+    }
+
+    @Test
+    fun originAwareOnlyBridge_providesOriginAwarePageFinishedBackfill() {
+        val bridge = WebViewJsBridge()
+        bridge.setRuntime(
+            AndroidOriginAwareWebViewJsBridgeRuntime(
+                AndroidWebViewJsBridgeConfig(
+                    allowedOriginRules = setOf("https://example.com"),
+                    policy = AndroidJsBridgePolicy.OriginAwareOnly,
+                ),
+            ),
+        )
+
+        val script = bridge.pageFinishedBootstrapScript()
+        assertNotNull(script)
+        assertTrue(script!!.contains("AppBridgeReady"))
+        assertTrue(script.contains("nativeBridge.postMessage"))
+    }
+
+    @Test
+    fun compatibleBridge_providesCompatibilityFallbackScript() {
+        val bridge = WebViewJsBridge()
+        bridge.setRuntime(
+            AndroidOriginAwareWebViewJsBridgeRuntime(
+                AndroidWebViewJsBridgeConfig(
+                    allowedOriginRules = setOf("https://example.com"),
+                    policy = AndroidJsBridgePolicy.Compatible,
+                ),
+            ),
+        )
+
+        val script = bridge.pageFinishedBootstrapScript()
+        assertNotNull(script)
+        assertTrue(script!!.contains("callMessage"))
+        assertTrue(script.contains("AppBridgeReady"))
+        assertTrue(script.contains("callMessage"))
+    }
+}

--- a/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewJsBridge.kt
+++ b/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewJsBridge.kt
@@ -23,15 +23,23 @@ class WebViewJsBridge(
 ) : NativeWebBridge {
     @PublishedApi internal val serializer: BridgeSerializer = serializer ?: defaultSerializer()
 
-    // Handler stores a suspend function that takes a JSON string and returns a JSON string (or null)
     @PublishedApi
-    internal val handlers = mutableMapOf<String, suspend (String?) -> String?>()
+    internal val handlers = mutableMapOf<String, BridgeRpcHandler>()
 
     @PublishedApi
     internal var webView: WebView? = null
 
     @PublishedApi
     internal val scope = CoroutineScope(Dispatchers.Main)
+
+    @PublishedApi
+    internal var runtime: WebViewJsBridgeRuntime = DefaultWebViewJsBridgeRuntime
+
+    /**
+     * Describes the runtime capabilities exposed by the currently installed transport.
+     */
+    val capabilities: BridgeCapabilities
+        get() = runtime.capabilities
 
     /**
      * The JavaScript code to inject into the WebView.
@@ -109,26 +117,60 @@ class WebViewJsBridge(
         method: String,
         noinline handler: suspend (T) -> R,
     ) {
-        handlers[method] = { jsonStr ->
-            val inputType = typeOf<T>()
-            val input =
-                if (jsonStr != null) {
-                    serializer.decode<T>(jsonStr, inputType)
-                } else {
-                    if (inputType == typeOf<Unit>()) {
-                        @Suppress("UNCHECKED_CAST")
-                        Unit as T
+        handlers[method] =
+            BridgeRpcHandler { _, jsonStr ->
+                val inputType = typeOf<T>()
+                val input =
+                    if (jsonStr != null) {
+                        serializer.decode<T>(jsonStr, inputType)
                     } else {
-                        throw IllegalArgumentException(
-                            "Input data is null but type is not nullable. " +
-                                "Use registerNullable<T, R>(...) for nullable payloads.",
-                        )
+                        if (inputType == typeOf<Unit>()) {
+                            @Suppress("UNCHECKED_CAST")
+                            Unit as T
+                        } else {
+                            throw IllegalArgumentException(
+                                "Input data is null but type is not nullable. " +
+                                    "Use registerNullable<T, R>(...) for nullable payloads.",
+                            )
+                        }
                     }
-                }
 
-            val result = handler(input)
-            serializer.encode(result, typeOf<R>())
-        }
+                val result = handler(input)
+                serializer.encode(result, typeOf<R>())
+            }
+    }
+
+    /**
+     * Registers a handler that receives invocation metadata for the calling frame.
+     *
+     * @param method The method name exposed to JavaScript.
+     * @param handler The handler invoked for that method.
+     */
+    inline fun <reified T : Any, reified R : Any> registerWithContext(
+        method: String,
+        noinline handler: suspend BridgeInvocationContext.(T) -> R,
+    ) {
+        handlers[method] =
+            BridgeRpcHandler { context, jsonStr ->
+                val inputType = typeOf<T>()
+                val input =
+                    if (jsonStr != null) {
+                        serializer.decode<T>(jsonStr, inputType)
+                    } else {
+                        if (inputType == typeOf<Unit>()) {
+                            @Suppress("UNCHECKED_CAST")
+                            Unit as T
+                        } else {
+                            throw IllegalArgumentException(
+                                "Input data is null but type is not nullable. " +
+                                    "Use registerNullable<T, R>(...) for nullable payloads.",
+                            )
+                        }
+                    }
+
+                val result = handler(context, input)
+                serializer.encode(result, typeOf<R>())
+            }
     }
 
     /**
@@ -142,10 +184,11 @@ class WebViewJsBridge(
         method: String,
         noinline handler: suspend () -> R,
     ) {
-        handlers[method] = { _ ->
-            val result = handler()
-            serializer.encode(result, typeOf<R>())
-        }
+        handlers[method] =
+            BridgeRpcHandler { _, _ ->
+                val result = handler()
+                serializer.encode(result, typeOf<R>())
+            }
     }
 
     /**
@@ -160,13 +203,14 @@ class WebViewJsBridge(
         method: String,
         noinline handler: suspend (T?) -> R,
     ) {
-        handlers[method] = { jsonStr ->
-            val inputType = typeOf<T>()
-            val input = if (jsonStr != null) serializer.decode<T>(jsonStr, inputType) else null
+        handlers[method] =
+            BridgeRpcHandler { _, jsonStr ->
+                val inputType = typeOf<T>()
+                val input = if (jsonStr != null) serializer.decode<T>(jsonStr, inputType) else null
 
-            val result = handler(input)
-            serializer.encode(result, typeOf<R>())
-        }
+                val result = handler(input)
+                serializer.encode(result, typeOf<R>())
+            }
     }
 
     /**
@@ -181,10 +225,17 @@ class WebViewJsBridge(
         data: T,
     ) {
         val jsonStr = serializer.encode(data, typeOf<T>())
+        emitSerialized(event, jsonStr)
+    }
+
+    @PublishedApi
+    internal fun emitSerialized(
+        event: String,
+        jsonPayload: String,
+    ) {
         // We need to run this on the main thread because it interacts with WebView
         scope.launch {
-            val script = "window.$jsObjectName.trigger('$event', $jsonStr);"
-            webView?.platformEvaluateJavascript(script, null)
+            runtime.emit(this@WebViewJsBridge, event, jsonPayload)
         }
     }
 
@@ -196,8 +247,26 @@ class WebViewJsBridge(
     }
 
     internal fun attach(webView: WebView) {
-        this.webView = webView
-        webView.platformAddJavascriptInterface(this, nativeInterfaceName)
+        runtime.attach(this, webView)
+    }
+
+    internal fun setRuntime(runtime: WebViewJsBridgeRuntime) {
+        this.runtime = runtime
+    }
+
+    internal fun pageFinishedBootstrapScript(): String? = runtime.pageFinishedBootstrapScript(this)
+
+    internal fun onPageStarted() {
+        runtime.onPageStarted(this)
+    }
+
+    internal suspend fun invokeHandler(
+        methodName: String,
+        data: String?,
+        context: BridgeInvocationContext,
+    ): String? {
+        val handler = handlers[methodName] ?: throw IllegalArgumentException("No handler found for method: $methodName")
+        return handler(context, data)
     }
 
     /**
@@ -205,6 +274,7 @@ class WebViewJsBridge(
      * This should be called when the bridge is no longer needed to prevent memory leaks.
      */
     fun dispose() {
+        runtime.dispose(this)
         scope.cancel()
         webView = null
     }
@@ -222,8 +292,13 @@ class WebViewJsBridge(
         data: String?,
         callbackId: String?,
     ) {
-        val handler = handlers[methodName]
-        if (handler == null) {
+        val context =
+            BridgeInvocationContext(
+                sourceOrigin = null,
+                isMainFrame = true,
+                transport = BridgeTransport.Compatibility,
+            )
+        if (handlers[methodName] == null) {
             if (callbackId != null) {
                 sendError(callbackId, "No handler found for method: $methodName")
             }
@@ -232,7 +307,7 @@ class WebViewJsBridge(
 
         scope.launch {
             try {
-                val resultJson = handler(data)
+                val resultJson = invokeHandler(methodName, data, context)
 
                 if (callbackId != null) {
                     sendSuccess(callbackId, resultJson)
@@ -270,6 +345,13 @@ class WebViewJsBridge(
         val script = "window.$jsObjectName.onError('$callbackId', $escapedError);"
         webView?.platformEvaluateJavascript(script, null)
     }
+}
+
+internal fun interface BridgeRpcHandler {
+    suspend operator fun invoke(
+        context: BridgeInvocationContext,
+        jsonPayload: String?,
+    ): String?
 }
 
 private fun defaultSerializer(): BridgeSerializer {

--- a/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewJsBridgeContracts.kt
+++ b/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewJsBridgeContracts.kt
@@ -1,0 +1,61 @@
+package com.parkwoocheol.composewebview
+
+/**
+ * Describes which bridge transport delivered a JavaScript call.
+ */
+enum class BridgeTransport {
+    /**
+     * Compatibility transport backed by the platform's classic bridge mechanism.
+     */
+    Compatibility,
+
+    /**
+     * Origin-aware transport backed by `addWebMessageListener`.
+     */
+    OriginAwareListener,
+
+    /**
+     * Dedicated message-channel transport backed by transferable ports.
+     */
+    MessageChannel,
+}
+
+/**
+ * Metadata about the JavaScript frame that invoked a bridge handler.
+ *
+ * @property sourceOrigin Origin string reported by the platform, or `null` when unavailable.
+ * @property isMainFrame Whether the call originated from the main frame.
+ * @property transport Which transport delivered this invocation.
+ */
+data class BridgeInvocationContext(
+    val sourceOrigin: String?,
+    val isMainFrame: Boolean,
+    val transport: BridgeTransport,
+)
+
+/**
+ * Runtime bridge capabilities exposed by the current platform transport.
+ *
+ * These values are transport-dependent and may change after a bridge attaches to a platform WebView.
+ *
+ * @property supportsOriginAwareInbound Whether inbound calls include origin/frame metadata from the platform.
+ * @property supportsBinaryMessages Whether binary bridge messaging is available.
+ * @property supportsPersistentReplyChannel Whether a frame-bound reply channel can stay active after a handler returns.
+ * @property supportsMainFrameOutboundMessaging Whether the bridge can post messages to the main frame without
+ * evaluating JavaScript strings.
+ */
+data class BridgeCapabilities(
+    val supportsOriginAwareInbound: Boolean = false,
+    val supportsBinaryMessages: Boolean = false,
+    val supportsPersistentReplyChannel: Boolean = false,
+    val supportsMainFrameOutboundMessaging: Boolean = false,
+)
+
+/**
+ * Marks Android bridge APIs whose transport contract may evolve in future minor releases.
+ */
+@RequiresOptIn(
+    message = "This Compose WebView API is experimental and may change without notice.",
+    level = RequiresOptIn.Level.ERROR,
+)
+annotation class ExperimentalComposeWebViewApi

--- a/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewJsBridgeRuntime.kt
+++ b/compose-webview/src/commonMain/kotlin/com/parkwoocheol/composewebview/WebViewJsBridgeRuntime.kt
@@ -1,0 +1,49 @@
+package com.parkwoocheol.composewebview
+
+internal interface WebViewJsBridgeRuntime {
+    val capabilities: BridgeCapabilities
+
+    fun attach(
+        bridge: WebViewJsBridge,
+        webView: WebView,
+    )
+
+    fun onPageStarted(bridge: WebViewJsBridge)
+
+    fun pageFinishedBootstrapScript(bridge: WebViewJsBridge): String?
+
+    fun emit(
+        bridge: WebViewJsBridge,
+        event: String,
+        payloadJson: String,
+    )
+
+    fun dispose(bridge: WebViewJsBridge)
+}
+
+internal object DefaultWebViewJsBridgeRuntime : WebViewJsBridgeRuntime {
+    override val capabilities: BridgeCapabilities = BridgeCapabilities()
+
+    override fun attach(
+        bridge: WebViewJsBridge,
+        webView: WebView,
+    ) {
+        bridge.webView = webView
+        webView.platformAddJavascriptInterface(bridge, bridge.nativeInterfaceName)
+    }
+
+    override fun onPageStarted(bridge: WebViewJsBridge) = Unit
+
+    override fun pageFinishedBootstrapScript(bridge: WebViewJsBridge): String? = bridge.jsScript
+
+    override fun emit(
+        bridge: WebViewJsBridge,
+        event: String,
+        payloadJson: String,
+    ) {
+        val script = "window.${bridge.jsObjectName}.trigger('$event', $payloadJson);"
+        bridge.webView?.platformEvaluateJavascript(script, null)
+    }
+
+    override fun dispose(bridge: WebViewJsBridge) = Unit
+}

--- a/compose-webview/src/commonTest/kotlin/com/parkwoocheol/composewebview/WebViewJsBridgeTest.kt
+++ b/compose-webview/src/commonTest/kotlin/com/parkwoocheol/composewebview/WebViewJsBridgeTest.kt
@@ -16,6 +16,13 @@ data class TestData(val id: Int, val name: String)
 data class TestResponse(val success: Boolean)
 
 class WebViewJsBridgeTest {
+    private val defaultContext =
+        BridgeInvocationContext(
+            sourceOrigin = null,
+            isMainFrame = true,
+            transport = BridgeTransport.Compatibility,
+        )
+
     @Test
     fun testRegisterAndCall() =
         runTest {
@@ -33,7 +40,7 @@ class WebViewJsBridgeTest {
             val handler = bridge.handlers["testMethod"]
             assertNotNull(handler)
 
-            val resultJson = handler(inputJson)
+            val resultJson = handler(defaultContext, inputJson)
             assertTrue(called)
             assertEquals("""{"success":true}""", resultJson)
         }
@@ -52,7 +59,7 @@ class WebViewJsBridgeTest {
             val handler = bridge.handlers["testNoArg"]
             assertNotNull(handler)
 
-            val resultJson = handler(null)
+            val resultJson = handler(defaultContext, null)
             assertTrue(called)
             assertEquals("""{"success":true}""", resultJson)
         }
@@ -71,7 +78,7 @@ class WebViewJsBridgeTest {
             val handler = bridge.handlers["refreshSession"]
             assertNotNull(handler)
 
-            val resultJson = handler(null)
+            val resultJson = handler(defaultContext, null)
             assertTrue(called)
             assertEquals("""{"success":true}""", resultJson)
         }
@@ -90,7 +97,7 @@ class WebViewJsBridgeTest {
 
             val exception =
                 assertFailsWith<IllegalArgumentException> {
-                    handler(null)
+                    handler(defaultContext, null)
                 }
             assertTrue(exception.message?.contains("registerNullable") == true)
         }
@@ -107,7 +114,7 @@ class WebViewJsBridgeTest {
             val handler = bridge.handlers["updateUserMaybe"]
             assertNotNull(handler)
 
-            val resultJson = handler(null)
+            val resultJson = handler(defaultContext, null)
             assertEquals("""{"success":true}""", resultJson)
         }
 
@@ -123,7 +130,7 @@ class WebViewJsBridgeTest {
             val handler = bridge.handlers["updateUserMaybe"]
             assertNotNull(handler)
 
-            val resultJson = handler("""{"id":1,"name":"Test"}""")
+            val resultJson = handler(defaultContext, """{"id":1,"name":"Test"}""")
             assertEquals("""{"success":true}""", resultJson)
         }
 
@@ -142,7 +149,7 @@ class WebViewJsBridgeTest {
             val handler = bridge.handlers["suspendMethod"]
             assertNotNull(handler)
 
-            val resultJson = handler("""{"id":1,"name":"Test"}""")
+            val resultJson = handler(defaultContext, """{"id":1,"name":"Test"}""")
             assertTrue(called)
             assertEquals("""{"success":true}""", resultJson)
         }
@@ -162,7 +169,7 @@ class WebViewJsBridgeTest {
             val handler = bridge.handlers["suspendNoArg"]
             assertNotNull(handler)
 
-            val resultJson = handler(null)
+            val resultJson = handler(defaultContext, null)
             assertTrue(called)
             assertEquals("""{"success":true}""", resultJson)
         }
@@ -180,7 +187,7 @@ class WebViewJsBridgeTest {
             val handler = bridge.handlers["suspendNullable"]
             assertNotNull(handler)
 
-            val resultJson = handler(null)
+            val resultJson = handler(defaultContext, null)
             assertEquals("""{"success":true}""", resultJson)
         }
 
@@ -197,7 +204,7 @@ class WebViewJsBridgeTest {
             val handler = bridge.handlers["suspendNullable"]
             assertNotNull(handler)
 
-            val resultJson = handler("""{"id":1,"name":"Test"}""")
+            val resultJson = handler(defaultContext, """{"id":1,"name":"Test"}""")
             assertEquals("""{"success":true}""", resultJson)
         }
 
@@ -216,7 +223,7 @@ class WebViewJsBridgeTest {
             val handler = bridge.handlers["suspendRefresh"]
             assertNotNull(handler)
 
-            val resultJson = handler(null)
+            val resultJson = handler(defaultContext, null)
             assertTrue(called)
             assertEquals("""{"success":true}""", resultJson)
         }
@@ -235,8 +242,33 @@ class WebViewJsBridgeTest {
 
             val exception =
                 assertFailsWith<IllegalArgumentException> {
-                    handler(null)
+                    handler(defaultContext, null)
                 }
             assertTrue(exception.message?.contains("registerNullable") == true)
+        }
+
+    @Test
+    fun testRegisterWithInvocationContext() =
+        runTest {
+            val bridge = WebViewJsBridge()
+            val invocationContext =
+                BridgeInvocationContext(
+                    sourceOrigin = "https://example.com",
+                    isMainFrame = false,
+                    transport = BridgeTransport.OriginAwareListener,
+                )
+
+            bridge.registerWithContext<TestData, TestResponse>("contextAware") { data ->
+                assertEquals("https://example.com", sourceOrigin)
+                assertEquals(false, isMainFrame)
+                assertEquals(BridgeTransport.OriginAwareListener, transport)
+                TestResponse(success = data.id == 7 && data.name == "Bridge")
+            }
+
+            val handler = bridge.handlers["contextAware"]
+            assertNotNull(handler)
+
+            val resultJson = handler(invocationContext, """{"id":7,"name":"Bridge"}""")
+            assertEquals("""{"success":true}""", resultJson)
         }
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,11 +14,11 @@ Before you begin, ensure your project meets the following requirements:
 
 ## Installation
 
-This library is available on **Maven Central** for universal access without authentication starting from **v1.6.0**.
+This library is available on **Maven Central** for universal access without authentication.
 
 !!! warning "Version Availability"
-    - **v1.6.1+ (future)**: Maven Central only (`io.github.parkwoocheol`)
-    - **v1.6.0 (current)**: Available on all repositories but uses different group IDs
+    - **v1.6.1 and later**: Maven Central only (`io.github.parkwoocheol`)
+    - **v1.6.0 (transitional)**: Available on all repositories but uses different group IDs
         - JitPack/GitHub Packages: `com.github.parkwoocheol:compose-webview:1.6.0`
         - Maven Central: `io.github.parkwoocheol:compose-webview:1.6.0` ← **Recommended**
     - **v1.5.x and earlier**: JitPack and GitHub Packages only (`com.github.parkwoocheol`)
@@ -110,9 +110,9 @@ If you previously used this library from JitPack or GitHub Packages:
 | Version | Repository | Group ID | Coordinates |
 |---------|------------|----------|-------------|
 | v1.5.x and earlier | JitPack, GitHub Packages | `com.github.parkwoocheol` | `com.github.parkwoocheol:compose-webview:1.5.x` |
-| **v1.6.0** (current) | JitPack, GitHub Packages | `com.github.parkwoocheol` | `com.github.parkwoocheol:compose-webview:1.6.0` |
-| **v1.6.0** (current) | **Maven Central** | `io.github.parkwoocheol` | `io.github.parkwoocheol:compose-webview:1.6.0` |
-| **v1.6.1+** (future) | **Maven Central only** | `io.github.parkwoocheol` | `io.github.parkwoocheol:compose-webview:1.6.1+` |
+| **v1.6.0** (transitional) | JitPack, GitHub Packages | `com.github.parkwoocheol` | `com.github.parkwoocheol:compose-webview:1.6.0` |
+| **v1.6.0** (transitional) | **Maven Central** | `io.github.parkwoocheol` | `io.github.parkwoocheol:compose-webview:1.6.0` |
+| **v1.6.1 and later** | **Maven Central only** | `io.github.parkwoocheol` | `io.github.parkwoocheol:compose-webview:<version>` |
 
 !!! info "v1.6.0 Group ID Difference"
     v1.6.0 uses different group IDs depending on the repository:
@@ -219,8 +219,8 @@ kotlin {
 
 !!! note "Backward Compatibility"
     - Old versions (v1.5.x and earlier) remain available on JitPack/GitHub Packages with `com.github` group ID
-    - v1.6.0 is the current and last version available on JitPack/GitHub Packages
-    - Future versions (v1.6.1+) will be Maven Central exclusive with `io.github` group ID
+    - `v1.6.0` is the last version available on JitPack/GitHub Packages
+    - `v1.6.1` and later are Maven Central exclusive with the `io.github` group ID
 
 ---
 

--- a/docs/guides/js-bridge.md
+++ b/docs/guides/js-bridge.md
@@ -43,6 +43,27 @@ val bridge = rememberWebViewJsBridge(
 )
 ```
 
+For Android web content served from origins listed in `allowedOriginRules`, prefer the origin-aware Android bridge:
+
+```kotlin
+val bridge =
+    rememberAndroidWebViewJsBridge(
+        config =
+            AndroidWebViewJsBridgeConfig(
+                allowedOriginRules = setOf("https://example.com"),
+                policy = AndroidJsBridgePolicy.OriginAwareOnly,
+            ),
+    )
+```
+
+Notes:
+- `rememberWebViewJsBridge()` remains the default cross-platform bridge.
+- On Android, the default bridge is compatibility-oriented and preserves the classic `addJavascriptInterface` flow.
+- `rememberAndroidWebViewJsBridge()` adds `allowedOriginRules`-backed listener bootstrap and optional compatibility
+  fallback.
+- `policy = Compatible` is a migration/fallback mode. It intentionally restores `addJavascriptInterface`-style
+  exposure for pages that do not receive the origin-aware bridge.
+
 ---
 
 ## Receiving Calls from JavaScript
@@ -114,6 +135,18 @@ bridge.registerNullable<UserRequest, User>("getUserMaybe") { requestOrNull ->
 }
 ```
 
+### Invocation Metadata
+
+Use `registerWithContext<T, R>` when you need source metadata from the calling frame.
+
+```kotlin
+bridge.registerWithContext<UserRequest, User>("getTrustedUser") { request ->
+    check(isMainFrame)
+    check(sourceOrigin == "https://example.com")
+    userRepository.findById(request.id)
+}
+```
+
 ### Suspend / Async Handlers
 
 All `register` and `registerNullable` methods accept **both regular and `suspend` lambdas**. This enables handlers that perform asynchronous operations (e.g., showing a dialog and waiting for user input, making a network call) before returning a result to JavaScript.
@@ -138,6 +171,51 @@ JavaScript callers don't need any changes — calls already return Promises:
 ```javascript
 const choice = await window.AppBridge.call('showConfirmDialog');
 console.log("User confirmed:", choice.confirmed);
+```
+
+### Android Experimental Message APIs
+
+`rememberAndroidWebViewJsBridge(...)` also unlocks experimental Android-only message APIs for raw string/binary
+messages and main-frame `WebMessageChannel` sessions.
+
+```kotlin
+@OptIn(ExperimentalComposeWebViewApi::class)
+LaunchedEffect(bridge) {
+    bridge.registerMessage("echoText") { message ->
+        when (message) {
+            is AndroidBridgeMessage.Text -> AndroidBridgeMessage.Text("echo:${message.value}")
+            is AndroidBridgeMessage.Binary -> AndroidBridgeMessage.Binary(message.value)
+        }
+    }
+
+    bridge.postMainFrameMessage(
+        targetOrigin = "https://example.com",
+        message = AndroidBridgeMessage.Text("native-ready"),
+    )
+
+    val session = bridge.openMainFrameSession("https://example.com")
+    session?.setMessageHandler { payload ->
+        println("Session payload: $payload")
+    }
+}
+```
+
+These APIs map directly to Android `postWebMessage` and `WebMessageChannel`. They are useful transport primitives,
+but they do not replace the inbound origin metadata and trust model provided by `addWebMessageListener`.
+
+JavaScript helpers added by the origin-aware Android bridge:
+
+```javascript
+window.AppBridge.onMessage((payload) => {
+  console.log('Native message:', payload);
+});
+
+window.AppBridge.onSession((session) => {
+  session.onMessage((payload) => console.log('Session payload:', payload));
+  session.postMessage('hello from JS session');
+});
+
+const echoed = await window.AppBridge.callMessage('echoText', 'hello');
 ```
 
 ---

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ testRunner = "1.6.2"
 composeBom = "2025.12.00"
 appcompat = "1.7.1"
 material = "1.12.0"
+androidxWebkit = "1.15.0"
 kotlinxSerializationJson = "1.9.0"
 composeMultiplatform = "1.9.3"
 jcef = "141.0.10"
@@ -38,6 +39,7 @@ androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "androidxWebkit" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinxCoroutines" }


### PR DESCRIPTION
## Summary

  This adds the Android JS bridge expansion planned for 1.9.0.

  - Adds Android-only `rememberAndroidWebViewJsBridge(...)`
  - Adds an origin-aware bridge path backed by `addWebMessageListener`
  - Adds Android experimental messaging support backed by `postWebMessage` and `WebMessageChannel`
  - Keeps the existing `rememberWebViewJsBridge()` path as the compatibility path
  - Finalizes the 1.9.0 release/docs/workflow preparation

  ## What Changed

  ### Common bridge
  - Added `BridgeInvocationContext`
  - Added `BridgeCapabilities`
  - Added `BridgeTransport`
  - Split bridge runtime handling through `WebViewJsBridgeRuntime`
  - Added `registerWithContext(...)`

  ### Android bridge
  - Added `AndroidWebViewJsBridgeConfig`
  - Added `AndroidJsBridgePolicy`
    - `OriginAwareOnly`
    - `Compatible`
  - Added `rememberAndroidWebViewJsBridge(...)`
  - Added `AndroidOriginAwareWebViewJsBridgeRuntime`
  - Added Android experimental APIs
    - `registerMessage(...)`
    - `postMainFrameMessage(...)`
    - `openMainFrameSession(...)`

  ### Android runtime behavior
  - The existing `rememberWebViewJsBridge()` path still uses the compatibility bridge path
  - The new Android origin-aware bridge uses listener/bootstrap behavior scoped by `allowedOriginRules`
  - Added transient reply/session invalidation on navigation start
  - Hardened bridge wrapper backfill for KeepAlive / reattach scenarios

  ### Tests / docs / release prep
  - Added Android runtime unit coverage
  - Updated the JS bridge guide, getting started docs, README, and CHANGELOG
  - Hardened build/docs/publish workflow gates
  - Added the debug test manifest dependency required for Android Compose instrumentation tests in this library module

  ## Compatibility / Side Effects

  - Existing Android consumers who keep using `rememberWebViewJsBridge()` do not get switched to the new origin-aware path automatically.
  - The origin-aware bridge is opt-in.
  - `androidx.compose.ui:ui-test-manifest` was added as `debugImplementation` only:
    - it is used only for Android debug/instrumentation testing
    - it is not included in the published release artifact
    - it does not affect iOS/Desktop/JS/WASM targets

  ## Verification

  Verified locally with:

  - `./gradlew spotlessApply`
  - `./gradlew :compose-webview:allTests`
  - `./gradlew :compose-webview:compileDebugAndroidTestKotlinAndroid`
  - `./gradlew :compose-webview:connectedDebugAndroidTest`
  - `bash .agents/skills/documentation/scripts/validate_docs.sh`
  - `mkdocs build --strict`